### PR TITLE
Add jck9 support to test.jck

### DIFF
--- a/openjdk.build/makefile
+++ b/openjdk.build/makefile
@@ -366,9 +366,9 @@ BUILD_COMMAND:=$(BUILD_COMMAND) -Djava9_home=$(JAVA9_HOME)
 # -java-args argument
 ifneq (,$(JAVA_ARGS))
   ifneq (,$(findstring jck,$(MAKECMDGOALS)))
-    JAVA_ARGS_ARG:=-java-args-setup="$(subst ",$(ESC_DQ),$(JAVA_ARGS))"
+    JAVA_ARGS_ARG=-java-args-setup="$(subst ",$(ESC_DQ),$(JAVA_ARGS))"
   else
-    JAVA_ARGS_ARG:=-java-args="$(subst ",$(ESC_DQ),$(JAVA_ARGS))"
+    JAVA_ARGS_ARG=-java-args="$(subst ",$(ESC_DQ),$(JAVA_ARGS))"
   endif
 endif
 

--- a/openjdk.test.jck/config/jck9/compiler.jti
+++ b/openjdk.test.jck/config/jck9/compiler.jti
@@ -1,9 +1,7 @@
 #JavaTest Harness Configuration Interview
-DESCRIPTION=
+DESCRIPTION=JCK9 compiler template jti for STF automation
 INTERVIEW=com.sun.jck.interview.JCKParameters
-LOCALE=en_US
 NAME=jck_compiler
-QUESTION=jck.env.envName
 # TESTSUITE example: /jck/jck9/JCK-compiler-9
 TESTSUITE=will_be_set_by_test_automation_at_run_time
 # WORKDIR example: /home/user/JCK-compiler-9
@@ -12,44 +10,40 @@ jck.concurrency.concurrency=1
 jck.env.compiler.agent.networkClassLoading=No
 jck.env.compiler.agent.passivePort=
 jck.env.compiler.agent.resourcesRemoving=No
-# jck.env.compiler.compRefExecute.cmdAsFile example: /home/user/jdk-9/jre/bin/java
+# jck.env.compiler.compRefExecute.cmdAsFile example: /home/user/jdk9/bin/java
 jck.env.compiler.compRefExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
 jck.env.compiler.compRefExecute.otherEnvVars=
 jck.env.compiler.compRefExecute.otherOpts=
 jck.env.compiler.rmi.tcpLower=
 jck.env.compiler.rmi.tcpRange=No
 jck.env.compiler.rmi.tcpUpper=
-jck.env.compiler.rmic=No
+jck.env.compiler.rmic=Yes
 jck.env.compiler.services.autostartServices=
 jck.env.compiler.services.servicesOn=No
 jck.env.compiler.testCompile.annoProc=-processor \#
 jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
-jck.env.compiler.testCompile.classpath=environment variable
-jck.env.compiler.testCompile.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.classpath=command line option
 jck.env.compiler.testCompile.classpathOpt=-classpath \#
-# jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk-9/jre/bin/javac
+# jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk9/bin/javac
 jck.env.compiler.testCompile.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk9/bin/javac
 jck.env.compiler.testCompile.compilerType=Java compiler API (JSR 199)
-jck.env.compiler.testCompile.compilerstaticsigtest=Yes
-# jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspath example /home/user/jdk-9/lib
-jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspath=will_be_set_by_test_automation_at_run_time
-jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=Yes
 jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.moduleOptions=Yes
 jck.env.compiler.testCompile.otherEnvVars=
-jck.env.compiler.testCompile.otherOpts=-source 1.9
+jck.env.compiler.testCompile.otherOpts=
 jck.env.compiler.testCompile.outDirOpt=-d \#
 jck.env.compiler.testCompile.outSrcDirOpt=-s \#
-jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=command line option
 jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
 jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
-# jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile example: /home/user/jdk-9/jre/bin/java
+# jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile example: /home/user/jdk9/bin/java
 jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile=will_be_set_by_test_automation_at_run_time
 jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
 jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
-jck.env.compiler.testRmic.classpath=environment variable
-jck.env.compiler.testRmic.classpathEnv=CLASSPATH
+jck.env.compiler.testRmic.classpath=command line option
 jck.env.compiler.testRmic.classpathOpt=-classpath \#
-# jck.env.compiler.testRmic.cmdAsFile example:  /home/user/jdk-9/bin/rmic
+# jck.env.compiler.testRmic.cmdAsFile example:  /home/user/jdk9/bin/rmic
 jck.env.compiler.testRmic.cmdAsFile=will_be_set_by_test_automation_at_run_time
 jck.env.compiler.testRmic.iiopOption=-iiop
 jck.env.compiler.testRmic.otherEnvVars=
@@ -57,103 +51,13 @@ jck.env.compiler.testRmic.otherOpts=
 jck.env.compiler.testRmic.outDirOpt=-d \#
 jck.env.compiler.testRmic.v11Option=-v1.1
 jck.env.compiler.testRmic.v12Option=-v1.2
-jck.env.description=
-jck.env.devtools.agent.networkClassLoading=No
-jck.env.devtools.agent.passivePort=
-jck.env.devtools.agent.resourcesRemoving=No
-jck.env.devtools.jaxb.defaultOperationMode=Yes
-jck.env.devtools.jaxb.needJaxbClasses=No
-jck.env.devtools.jaxb.skipJ2XOptional=Yes
-jck.env.devtools.refExecute.otherEnvVars=
-jck.env.devtools.refExecute.otherOpts=
-jck.env.devtools.scriptEnvVars=
-jck.env.devtools.services.autostartServices=
-jck.env.devtools.services.servicesOn=No
-jck.env.devtools.testExecute.classpath=command line option
-jck.env.devtools.testExecute.classpathEnv=CLASSPATH
-jck.env.devtools.testExecute.classpathOpt=-classpath \#
-jck.env.devtools.testExecute.otherEnvVars=
-jck.env.devtools.testExecute.otherOpts=
-jck.env.envName=jck_compiler_linux_mod
-jck.env.mode=classpath
-jck.env.modules=
+jck.env.description=JCK9 compiler template jti for STF automation
+jck.env.envName=jck_compiler
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=--add-modules \#[,\#]\ncompilerModulePathOptionTemplate\=--module-path \#\ncompilerModuleSourcePathOptionTemplate\=--module-source-path \#\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=\nvmModulePathOptionTemplate\=\nvmAddModsOptionTemplate\=\n
+jck.env.platform=jre
+jck.env.platformModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
 jck.env.product=compiler
-jck.env.profile=4
-jck.env.runtime.agent.networkClassLoading=No
-jck.env.runtime.agent.passivePort=
-jck.env.runtime.agent.resourcesRemoving=No
-jck.env.runtime.audio.canPlayMidi=Yes
-jck.env.runtime.audio.canPlaySound=Yes
-jck.env.runtime.audio.canRecordSound=Yes
-jck.env.runtime.audio.soundURLChoice=Yes
-jck.env.runtime.audio.soundURLYesJCK=.WAV
-jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
-jck.env.runtime.awt.robotAvailable=Yes
-jck.env.runtime.awt.splashScreenOpt=-splash\:\#
-jck.env.runtime.awt.splashScreenSupported=Yes
-jck.env.runtime.fp.doubleMaxExponent=
-jck.env.runtime.fp.doubleMinExponent=
-jck.env.runtime.fp.floatMaxExponent=
-jck.env.runtime.fp.floatMinExponent=
-jck.env.runtime.fp.supportExtended=No
-jck.env.runtime.ftpSupport=Yes
-# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
-jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
-jck.env.runtime.idl.orbPort=
-jck.env.runtime.jaas.authPolicy=standard system property
-jck.env.runtime.jaas.loginConfig=standard system property
-jck.env.runtime.jdwp.VMSuspended=Yes
-jck.env.runtime.jdwp.connectorType=attaching
-jck.env.runtime.jdwp.jdwpSupported=Yes
-jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
-jck.env.runtime.jgss.loginModule=No
-jck.env.runtime.jplis.jplisCmdLine=Yes
-jck.env.runtime.jplis.jplisLivePhase=Yes
-jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
-jck.env.runtime.jsse.isJKSSupported=Yes
-jck.env.runtime.memory.expectOutOfMemory=Yes
-jck.env.runtime.memory.memoryAllocation=Yes
-# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
-jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
-# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
-jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
-jck.env.runtime.net.tcpLower=
-jck.env.runtime.net.tcpRange=No
-jck.env.runtime.net.tcpUpper=
-jck.env.runtime.net.udpLower=
-jck.env.runtime.net.udpRange=No
-jck.env.runtime.net.udpUpper=
-jck.env.runtime.print.hasPrinter=Yes
-jck.env.runtime.remoteAgent.loadClasses=No
-jck.env.runtime.remoteAgent.passivePort=
-jck.env.runtime.remoteAgent.passivePortDefault=Yes
-jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
-jck.env.runtime.services.autostartServices=
-jck.env.runtime.services.servicesOn=No
-jck.env.runtime.staticsigtest.supportStaticSigTest=No
-jck.env.runtime.testExecute.activationPortValue=
-jck.env.runtime.testExecute.classpath=command line option
-jck.env.runtime.testExecute.classpathEnv=CLASSPATH
-jck.env.runtime.testExecute.classpathOpt=-classpath \#
-jck.env.runtime.testExecute.jarExecution=Yes
-jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
-jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
-jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
-jck.env.runtime.testExecute.libPath=environment variable
-jck.env.runtime.testExecute.modulepathOpt=-L \#
-jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
-jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
-jck.env.runtime.testExecute.optionSpecification=Yes
-jck.env.runtime.testExecute.otherEnvVars=
-jck.env.runtime.testExecute.otherOpts=
-jck.env.runtime.testExecute.rmiActivationSupport=No
-jck.env.runtime.testExecute.stdActivationPort=Yes
-jck.env.runtime.testExecute.supportIIOP=No
-jck.env.runtime.testExecute.verify=-Xfuture
-# jck.env.runtime.url.ftpURL example: ftp\://ftp.w3.org/welcome.msg
-jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
-# jck.env.runtime.url.httpURL example: http\://www.iana.org/domains/example/index.html
-jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
 jck.env.simpleOrAdvanced=advanced
 # jck.env.testPlatform.display example: :1 or xxxx.xxxx.xxxx.com\:0.0
 jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
@@ -166,8 +70,7 @@ jck.env.testPlatform.os=Current system
 jck.env.testPlatform.processCreationSupport=Yes
 jck.env.testPlatform.proxyPort=
 jck.env.testPlatform.remoteNetworking=Remote network support
-# jck.env.testPlatform.systemRoot example: C\:\\WINDOWS
-jck.env.testPlatform.systemRoot=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.systemRoot=C\:\\windows
 jck.env.testPlatform.typecheckerSpecific=Yes
 jck.env.testPlatform.useAgent=No
 # jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
@@ -178,12 +81,15 @@ jck.excludeList.latestAutoCheckInterval=7
 jck.excludeList.latestAutoCheckMode=everyXDays
 jck.excludeList.needExcludeList=Yes
 jck.keywords.keywords.mode=expr
-jck.keywords.keywords.value=
-jck.keywords.needKeywords=No
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
+jck.keywords.needKeywords=Yes
 jck.knownFailuresList.needKfl=No
 jck.priorStatus.needStatus=No
 jck.priorStatus.status=
-jck.tests.needTests=Yes
-jck.tests.tests=api/javax_tools api/signaturetest
+jck.tests.chooseTests=Yes
+jck.tests.needTests=No
+jck.tests.setOfModules=
+jck.tests.tests=
 jck.tests.treeOrFile=tree
 jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck9/compiler.jti
+++ b/openjdk.test.jck/config/jck9/compiler.jti
@@ -1,0 +1,189 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_compiler
+QUESTION=jck.env.envName
+# TESTSUITE example: /jck/jck9/JCK-compiler-9
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-compiler-9
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.compiler.agent.networkClassLoading=No
+jck.env.compiler.agent.passivePort=
+jck.env.compiler.agent.resourcesRemoving=No
+# jck.env.compiler.compRefExecute.cmdAsFile example: /home/user/jdk-9/jre/bin/java
+jck.env.compiler.compRefExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.compRefExecute.otherEnvVars=
+jck.env.compiler.compRefExecute.otherOpts=
+jck.env.compiler.rmi.tcpLower=
+jck.env.compiler.rmi.tcpRange=No
+jck.env.compiler.rmi.tcpUpper=
+jck.env.compiler.rmic=No
+jck.env.compiler.services.autostartServices=
+jck.env.compiler.services.servicesOn=No
+jck.env.compiler.testCompile.annoProc=-processor \#
+jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
+jck.env.compiler.testCompile.classpath=environment variable
+jck.env.compiler.testCompile.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.classpathOpt=-classpath \#
+# jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk-9/jre/bin/javac
+jck.env.compiler.testCompile.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.compilerType=Java compiler API (JSR 199)
+jck.env.compiler.testCompile.compilerstaticsigtest=Yes
+# jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspath example /home/user/jdk-9/lib
+jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspath=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=Yes
+jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.otherEnvVars=
+jck.env.compiler.testCompile.otherOpts=-source 1.9
+jck.env.compiler.testCompile.outDirOpt=-d \#
+jck.env.compiler.testCompile.outSrcDirOpt=-s \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
+# jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile example: /home/user/jdk-9/jre/bin/java
+jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
+jck.env.compiler.testRmic.classpath=environment variable
+jck.env.compiler.testRmic.classpathEnv=CLASSPATH
+jck.env.compiler.testRmic.classpathOpt=-classpath \#
+# jck.env.compiler.testRmic.cmdAsFile example:  /home/user/jdk-9/bin/rmic
+jck.env.compiler.testRmic.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testRmic.iiopOption=-iiop
+jck.env.compiler.testRmic.otherEnvVars=
+jck.env.compiler.testRmic.otherOpts=
+jck.env.compiler.testRmic.outDirOpt=-d \#
+jck.env.compiler.testRmic.v11Option=-v1.1
+jck.env.compiler.testRmic.v12Option=-v1.2
+jck.env.description=
+jck.env.devtools.agent.networkClassLoading=No
+jck.env.devtools.agent.passivePort=
+jck.env.devtools.agent.resourcesRemoving=No
+jck.env.devtools.jaxb.defaultOperationMode=Yes
+jck.env.devtools.jaxb.needJaxbClasses=No
+jck.env.devtools.jaxb.skipJ2XOptional=Yes
+jck.env.devtools.refExecute.otherEnvVars=
+jck.env.devtools.refExecute.otherOpts=
+jck.env.devtools.scriptEnvVars=
+jck.env.devtools.services.autostartServices=
+jck.env.devtools.services.servicesOn=No
+jck.env.devtools.testExecute.classpath=command line option
+jck.env.devtools.testExecute.classpathEnv=CLASSPATH
+jck.env.devtools.testExecute.classpathOpt=-classpath \#
+jck.env.devtools.testExecute.otherEnvVars=
+jck.env.devtools.testExecute.otherOpts=
+jck.env.envName=jck_compiler_linux_mod
+jck.env.mode=classpath
+jck.env.modules=
+jck.env.product=compiler
+jck.env.profile=4
+jck.env.runtime.agent.networkClassLoading=No
+jck.env.runtime.agent.passivePort=
+jck.env.runtime.agent.resourcesRemoving=No
+jck.env.runtime.audio.canPlayMidi=Yes
+jck.env.runtime.audio.canPlaySound=Yes
+jck.env.runtime.audio.canRecordSound=Yes
+jck.env.runtime.audio.soundURLChoice=Yes
+jck.env.runtime.audio.soundURLYesJCK=.WAV
+jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
+jck.env.runtime.awt.robotAvailable=Yes
+jck.env.runtime.awt.splashScreenOpt=-splash\:\#
+jck.env.runtime.awt.splashScreenSupported=Yes
+jck.env.runtime.fp.doubleMaxExponent=
+jck.env.runtime.fp.doubleMinExponent=
+jck.env.runtime.fp.floatMaxExponent=
+jck.env.runtime.fp.floatMinExponent=
+jck.env.runtime.fp.supportExtended=No
+jck.env.runtime.ftpSupport=Yes
+# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
+jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.idl.orbPort=
+jck.env.runtime.jaas.authPolicy=standard system property
+jck.env.runtime.jaas.loginConfig=standard system property
+jck.env.runtime.jdwp.VMSuspended=Yes
+jck.env.runtime.jdwp.connectorType=attaching
+jck.env.runtime.jdwp.jdwpSupported=Yes
+jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
+jck.env.runtime.jgss.loginModule=No
+jck.env.runtime.jplis.jplisCmdLine=Yes
+jck.env.runtime.jplis.jplisLivePhase=Yes
+jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
+jck.env.runtime.jsse.isJKSSupported=Yes
+jck.env.runtime.memory.expectOutOfMemory=Yes
+jck.env.runtime.memory.memoryAllocation=Yes
+# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
+jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.tcpLower=
+jck.env.runtime.net.tcpRange=No
+jck.env.runtime.net.tcpUpper=
+jck.env.runtime.net.udpLower=
+jck.env.runtime.net.udpRange=No
+jck.env.runtime.net.udpUpper=
+jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.remoteAgent.loadClasses=No
+jck.env.runtime.remoteAgent.passivePort=
+jck.env.runtime.remoteAgent.passivePortDefault=Yes
+jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
+jck.env.runtime.services.autostartServices=
+jck.env.runtime.services.servicesOn=No
+jck.env.runtime.staticsigtest.supportStaticSigTest=No
+jck.env.runtime.testExecute.activationPortValue=
+jck.env.runtime.testExecute.classpath=command line option
+jck.env.runtime.testExecute.classpathEnv=CLASSPATH
+jck.env.runtime.testExecute.classpathOpt=-classpath \#
+jck.env.runtime.testExecute.jarExecution=Yes
+jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
+jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
+jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
+jck.env.runtime.testExecute.libPath=environment variable
+jck.env.runtime.testExecute.modulepathOpt=-L \#
+jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
+jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
+jck.env.runtime.testExecute.optionSpecification=Yes
+jck.env.runtime.testExecute.otherEnvVars=
+jck.env.runtime.testExecute.otherOpts=
+jck.env.runtime.testExecute.rmiActivationSupport=No
+jck.env.runtime.testExecute.stdActivationPort=Yes
+jck.env.runtime.testExecute.supportIIOP=No
+jck.env.runtime.testExecute.verify=-Xfuture
+# jck.env.runtime.url.ftpURL example: ftp\://ftp.w3.org/welcome.msg
+jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.httpURL example: http\://www.iana.org/domains/example/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: :1 or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+# jck.env.testPlatform.systemRoot example: C\:\\WINDOWS
+jck.env.testPlatform.systemRoot=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=
+jck.keywords.needKeywords=No
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.needTests=Yes
+jck.tests.tests=api/javax_tools api/signaturetest
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck9/devtools.jti
+++ b/openjdk.test.jck/config/jck9/devtools.jti
@@ -1,165 +1,55 @@
 #JavaTest Harness Configuration Interview
-DESCRIPTION=JCK-9
+DESCRIPTION=JCK9 devtools template jti for STF automation
 INTERVIEW=com.sun.jck.interview.JCKParameters
 LOCALE=en_US
 NAME=jck_devtools
-QUESTION=jck.env.devtools.scriptEnvVars
 # TESTSUITE example: /jck/jck9/JCK-devtools-9
 TESTSUITE=will_be_set_by_test_automation_at_run_time
 # WORKDIR example: /home/user/JCK-devtools-9
 WORKDIR=will_be_set_by_test_automation_at_run_time
 jck.concurrency.concurrency=1
-jck.env.compiler.agent.networkClassLoading=No
-jck.env.compiler.agent.passivePort=
-jck.env.compiler.agent.resourcesRemoving=No
-jck.env.compiler.compRefExecute.otherEnvVars=
-jck.env.compiler.compRefExecute.otherOpts=
-jck.env.compiler.rmi.tcpLower=
-jck.env.compiler.rmi.tcpRange=No
-jck.env.compiler.rmi.tcpUpper=
-jck.env.compiler.services.autostartServices=
-jck.env.compiler.services.servicesOn=No
-jck.env.compiler.testCompile.annoProc=-processor \#
-jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
-jck.env.compiler.testCompile.classpath=command line option
-jck.env.compiler.testCompile.classpathOpt=-classpath \#
-jck.env.compiler.testCompile.compilerType=command line tool
-jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=No
-jck.env.compiler.testCompile.defaultCompiler=Yes
-jck.env.compiler.testCompile.otherEnvVars=
-jck.env.compiler.testCompile.otherOpts=
-jck.env.compiler.testCompile.outDirOpt=-d \#
-jck.env.compiler.testCompile.outSrcDirOpt=-s \#
-jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
-jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
-jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
-jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
-jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
-jck.env.compiler.testRmic.classpath=command line option
-jck.env.compiler.testRmic.classpathOpt=-classpath \#
-jck.env.compiler.testRmic.iiopOption=-iiop
-jck.env.compiler.testRmic.otherEnvVars=
-jck.env.compiler.testRmic.otherOpts=
-jck.env.compiler.testRmic.outDirOpt=-d \#
-jck.env.compiler.testRmic.v11Option=-v1.1
-jck.env.compiler.testRmic.v12Option=-v1.2
-jck.env.description=JCK-9
+jck.env.description=devtools.jit for STF automation
 jck.env.devtools.agent.networkClassLoading=No
 jck.env.devtools.agent.passivePort=
 jck.env.devtools.agent.resourcesRemoving=No
-jck.env.devtools.jaxb=Yes
 jck.env.devtools.jaxb.defaultOperationMode=Yes
 jck.env.devtools.jaxb.java2schema=Yes
-# jck.env.devtools.jaxb.jxcCmd example: =/jck/jck9/JCK-devtools-9/linux/bin/schemagen.sh
+# jck.env.devtools.jaxb.jxcCmd example: /jck/jck9/JCK-devtools-9/linux/bin/schemagen
 jck.env.devtools.jaxb.jxcCmd=will_be_set_by_test_automation_at_run_time
 jck.env.devtools.jaxb.needJaxbClasses=No
 jck.env.devtools.jaxb.skipJ2XOptional=Yes
-jck.env.devtools.jaxb.xjcCmd example: /jck/jck9/JCK-devtools-9/linux/bin/xjc.sh
+# jck.env.devtools.jaxb.xjcCmd=/jck/jck9/JCK-devtools-9/linux/bin/xjc
 jck.env.devtools.jaxb.xjcCmd=will_be_set_by_test_automation_at_run_time
 jck.env.devtools.jaxb.xml_schema=Yes
-jck.env.devtools.jaxws=Yes
-# jck.env.devtools.jaxws.cmdJavac example: /home/user/jdk-9/bin/javac
+jck.env.devtools.jaxb=Yes
+# jck.env.devtools.jaxws.cmdJavac=/home/user/jdk/jdk9/bin/javac
 jck.env.devtools.jaxws.cmdJavac=will_be_set_by_test_automation_at_run_time
-# jck.env.devtools.jaxws.genCmd example: /jck/jck9/JCK-devtools-9/linux/bin/wsgen.sh
+# jck.env.devtools.jaxws.genCmd=/jck/jck9/JCK-devtools-9/linux/bin/wsgen
 jck.env.devtools.jaxws.genCmd=will_be_set_by_test_automation_at_run_time
-# jck.env.devtools.jaxws.impCmd example: /jck/jck9/JCK-devtools-9/linux/bin/wsimport.sh
+# jck.env.devtools.jaxws.impCmd=/jck/jck9/JCK-devtools-9/linux/bin/wsimport
 jck.env.devtools.jaxws.impCmd=will_be_set_by_test_automation_at_run_time
-# jck.env.devtools.refExecute.cmdAsFile example: /home/user/jdk-9/bin/java
+jck.env.devtools.jaxws=Yes
+# jck.env.devtools.refExecute.cmdAsFile=/home/user/jdk/jdk9/bin/java
 jck.env.devtools.refExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
 jck.env.devtools.refExecute.otherEnvVars=
 jck.env.devtools.refExecute.otherOpts=
-# jck.env.devtools.scriptEnvVars example: JAVA_HOME\=/home/user/jdk-9/
-jck.env.devtools.scriptEnvVars=JAVA_HOME\=will_be_set_by_test_automation_at_run_time
-jck.env.devtools.services.autostartServices=Agent
+jck.env.devtools.scriptEnvVars=
+jck.env.devtools.services.autostartServices=
 jck.env.devtools.services.servicesOn=No
 jck.env.devtools.testExecute.additionalClasspath=
 jck.env.devtools.testExecute.classpath=command line option
 jck.env.devtools.testExecute.classpathEnv=CLASSPATH
-jck.env.devtools.testExecute.classpathOpt=/cp\:\#
-# jck.env.devtools.testExecute.cmdAsFile example: /home/user/jdk-9/bin/java
+jck.env.devtools.testExecute.classpathOpt=-classpath \#
+# jck.env.devtools.testExecute.cmdAsFile=/home/user/jdk/jdk9/bin/java
 jck.env.devtools.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
 jck.env.devtools.testExecute.otherEnvVars=
 jck.env.devtools.testExecute.otherOpts=
 jck.env.envName=jck_devtools
-jck.env.mode=classpath
-jck.env.modules=
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=\ncompilerModulePathOptionTemplate\=\ncompilerModuleSourcePathOptionTemplate\=\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=\nvmModulePathOptionTemplate\=\nvmAddModsOptionTemplate\=\n
+jck.env.platform=jre
+jck.env.platformModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
 jck.env.product=devtools
-jck.env.profile=4
-jck.env.runtime.agent.networkClassLoading=No
-jck.env.runtime.agent.passivePort=
-jck.env.runtime.agent.resourcesRemoving=No
-jck.env.runtime.audio.canPlayMidi=Yes
-jck.env.runtime.audio.canPlaySound=Yes
-jck.env.runtime.audio.canRecordSound=Yes
-jck.env.runtime.audio.soundURLChoice=Yes
-jck.env.runtime.audio.soundURLYesJCK=.WAV
-jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
-jck.env.runtime.awt.robotAvailable=Yes
-jck.env.runtime.awt.splashScreenOpt=-splash\:\#
-jck.env.runtime.awt.splashScreenSupported=Yes
-jck.env.runtime.fp.doubleMaxExponent=
-jck.env.runtime.fp.doubleMinExponent=
-jck.env.runtime.fp.floatMaxExponent=
-jck.env.runtime.fp.floatMinExponent=
-jck.env.runtime.fp.supportExtended=No
-jck.env.runtime.ftpSupport=Yes
-# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
-jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
-jck.env.runtime.idl.orbPort=
-jck.env.runtime.jaas.authPolicy=standard system property
-jck.env.runtime.jaas.loginConfig=standard system property
-jck.env.runtime.jdwp.VMSuspended=Yes
-jck.env.runtime.jdwp.connectorType=attaching
-jck.env.runtime.jdwp.jdwpSupported=Yes
-jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
-jck.env.runtime.jgss.loginModule=No
-jck.env.runtime.jplis.jplisCmdLine=Yes
-jck.env.runtime.jplis.jplisLivePhase=Yes
-jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
-jck.env.runtime.jsse.isJKSSupported=Yes
-jck.env.runtime.memory.expectOutOfMemory=Yes
-jck.env.runtime.memory.memoryAllocation=Yes
-# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
-jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
-# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
-jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
-jck.env.runtime.net.tcpLower=
-jck.env.runtime.net.tcpRange=No
-jck.env.runtime.net.tcpUpper=
-jck.env.runtime.net.udpLower=
-jck.env.runtime.net.udpRange=No
-jck.env.runtime.net.udpUpper=
-jck.env.runtime.print.hasPrinter=Yes
-jck.env.runtime.remoteAgent.loadClasses=No
-jck.env.runtime.remoteAgent.passivePort=
-jck.env.runtime.remoteAgent.passivePortDefault=Yes
-jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
-jck.env.runtime.services.autostartServices=
-jck.env.runtime.services.servicesOn=No
-jck.env.runtime.staticsigtest.supportStaticSigTest=No
-jck.env.runtime.testExecute.activationPortValue=
-jck.env.runtime.testExecute.classpath=command line option
-jck.env.runtime.testExecute.classpathEnv=CLASSPATH
-jck.env.runtime.testExecute.classpathOpt=-classpath \#
-jck.env.runtime.testExecute.jarExecution=Yes
-jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
-jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
-jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
-jck.env.runtime.testExecute.libPath=environment variable
-jck.env.runtime.testExecute.modulepathOpt=-L \#
-jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
-jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
-jck.env.runtime.testExecute.optionSpecification=Yes
-jck.env.runtime.testExecute.otherEnvVars=
-jck.env.runtime.testExecute.otherOpts=
-jck.env.runtime.testExecute.rmiActivationSupport=No
-jck.env.runtime.testExecute.stdActivationPort=Yes
-jck.env.runtime.testExecute.supportIIOP=No
-jck.env.runtime.testExecute.verify=-Xfuture
-# jck.env.runtime.url.ftpURL example: ftp\://xxxx.xxxx.xxxx.com/xxx.txt
-jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
-# jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
-jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
 jck.env.simpleOrAdvanced=advanced
 # jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
 jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
@@ -170,11 +60,12 @@ jck.env.testPlatform.nativeCode=Yes
 jck.env.testPlatform.needProxy=No
 jck.env.testPlatform.os=Current system
 jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyHost=
 jck.env.testPlatform.proxyPort=
 jck.env.testPlatform.remoteNetworking=Remote network support
 jck.env.testPlatform.typecheckerSpecific=Yes
 jck.env.testPlatform.useAgent=No
-# jck.excludeList.customFiles example: /jck/jck8b/excludes\\jck8b.jtx
+# jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
 jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
 jck.excludeList.excludeListType=custom
 jck.excludeList.latestAutoCheck=No
@@ -182,14 +73,15 @@ jck.excludeList.latestAutoCheckInterval=7
 jck.excludeList.latestAutoCheckMode=everyXDays
 jck.excludeList.needExcludeList=Yes
 jck.keywords.keywords.mode=expr
-jck.keywords.keywords.value=
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
 jck.keywords.needKeywords=No
-# jck.knownFailuresList.customFiles example: /jck/jck8b/excludes/jck8b.kfl
-jck.knownFailuresList.customFiles=will_be_set_by_test_automation_at_run_time
 jck.knownFailuresList.needKfl=No
 jck.priorStatus.needStatus=No
 jck.priorStatus.status=
+jck.tests.chooseTests=Yes
 jck.tests.needTests=No
+jck.tests.setOfModules=
 jck.tests.tests=
 jck.tests.treeOrFile=tree
 jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck9/devtools.jti
+++ b/openjdk.test.jck/config/jck9/devtools.jti
@@ -1,0 +1,195 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK-9
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_devtools
+QUESTION=jck.env.devtools.scriptEnvVars
+# TESTSUITE example: /jck/jck9/JCK-devtools-9
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-devtools-9
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.compiler.agent.networkClassLoading=No
+jck.env.compiler.agent.passivePort=
+jck.env.compiler.agent.resourcesRemoving=No
+jck.env.compiler.compRefExecute.otherEnvVars=
+jck.env.compiler.compRefExecute.otherOpts=
+jck.env.compiler.rmi.tcpLower=
+jck.env.compiler.rmi.tcpRange=No
+jck.env.compiler.rmi.tcpUpper=
+jck.env.compiler.services.autostartServices=
+jck.env.compiler.services.servicesOn=No
+jck.env.compiler.testCompile.annoProc=-processor \#
+jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
+jck.env.compiler.testCompile.classpath=command line option
+jck.env.compiler.testCompile.classpathOpt=-classpath \#
+jck.env.compiler.testCompile.compilerType=command line tool
+jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=No
+jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.otherEnvVars=
+jck.env.compiler.testCompile.otherOpts=
+jck.env.compiler.testCompile.outDirOpt=-d \#
+jck.env.compiler.testCompile.outSrcDirOpt=-s \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
+jck.env.compiler.testRmic.classpath=command line option
+jck.env.compiler.testRmic.classpathOpt=-classpath \#
+jck.env.compiler.testRmic.iiopOption=-iiop
+jck.env.compiler.testRmic.otherEnvVars=
+jck.env.compiler.testRmic.otherOpts=
+jck.env.compiler.testRmic.outDirOpt=-d \#
+jck.env.compiler.testRmic.v11Option=-v1.1
+jck.env.compiler.testRmic.v12Option=-v1.2
+jck.env.description=JCK-9
+jck.env.devtools.agent.networkClassLoading=No
+jck.env.devtools.agent.passivePort=
+jck.env.devtools.agent.resourcesRemoving=No
+jck.env.devtools.jaxb=Yes
+jck.env.devtools.jaxb.defaultOperationMode=Yes
+jck.env.devtools.jaxb.java2schema=Yes
+# jck.env.devtools.jaxb.jxcCmd example: =/jck/jck9/JCK-devtools-9/linux/bin/schemagen.sh
+jck.env.devtools.jaxb.jxcCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxb.needJaxbClasses=No
+jck.env.devtools.jaxb.skipJ2XOptional=Yes
+jck.env.devtools.jaxb.xjcCmd example: /jck/jck9/JCK-devtools-9/linux/bin/xjc.sh
+jck.env.devtools.jaxb.xjcCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxb.xml_schema=Yes
+jck.env.devtools.jaxws=Yes
+# jck.env.devtools.jaxws.cmdJavac example: /home/user/jdk-9/bin/javac
+jck.env.devtools.jaxws.cmdJavac=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.jaxws.genCmd example: /jck/jck9/JCK-devtools-9/linux/bin/wsgen.sh
+jck.env.devtools.jaxws.genCmd=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.jaxws.impCmd example: /jck/jck9/JCK-devtools-9/linux/bin/wsimport.sh
+jck.env.devtools.jaxws.impCmd=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.refExecute.cmdAsFile example: /home/user/jdk-9/bin/java
+jck.env.devtools.refExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.refExecute.otherEnvVars=
+jck.env.devtools.refExecute.otherOpts=
+# jck.env.devtools.scriptEnvVars example: JAVA_HOME\=/home/user/jdk-9/
+jck.env.devtools.scriptEnvVars=JAVA_HOME\=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.services.autostartServices=Agent
+jck.env.devtools.services.servicesOn=No
+jck.env.devtools.testExecute.additionalClasspath=
+jck.env.devtools.testExecute.classpath=command line option
+jck.env.devtools.testExecute.classpathEnv=CLASSPATH
+jck.env.devtools.testExecute.classpathOpt=/cp\:\#
+# jck.env.devtools.testExecute.cmdAsFile example: /home/user/jdk-9/bin/java
+jck.env.devtools.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.testExecute.otherEnvVars=
+jck.env.devtools.testExecute.otherOpts=
+jck.env.envName=jck_devtools
+jck.env.mode=classpath
+jck.env.modules=
+jck.env.product=devtools
+jck.env.profile=4
+jck.env.runtime.agent.networkClassLoading=No
+jck.env.runtime.agent.passivePort=
+jck.env.runtime.agent.resourcesRemoving=No
+jck.env.runtime.audio.canPlayMidi=Yes
+jck.env.runtime.audio.canPlaySound=Yes
+jck.env.runtime.audio.canRecordSound=Yes
+jck.env.runtime.audio.soundURLChoice=Yes
+jck.env.runtime.audio.soundURLYesJCK=.WAV
+jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
+jck.env.runtime.awt.robotAvailable=Yes
+jck.env.runtime.awt.splashScreenOpt=-splash\:\#
+jck.env.runtime.awt.splashScreenSupported=Yes
+jck.env.runtime.fp.doubleMaxExponent=
+jck.env.runtime.fp.doubleMinExponent=
+jck.env.runtime.fp.floatMaxExponent=
+jck.env.runtime.fp.floatMinExponent=
+jck.env.runtime.fp.supportExtended=No
+jck.env.runtime.ftpSupport=Yes
+# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
+jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.idl.orbPort=
+jck.env.runtime.jaas.authPolicy=standard system property
+jck.env.runtime.jaas.loginConfig=standard system property
+jck.env.runtime.jdwp.VMSuspended=Yes
+jck.env.runtime.jdwp.connectorType=attaching
+jck.env.runtime.jdwp.jdwpSupported=Yes
+jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
+jck.env.runtime.jgss.loginModule=No
+jck.env.runtime.jplis.jplisCmdLine=Yes
+jck.env.runtime.jplis.jplisLivePhase=Yes
+jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
+jck.env.runtime.jsse.isJKSSupported=Yes
+jck.env.runtime.memory.expectOutOfMemory=Yes
+jck.env.runtime.memory.memoryAllocation=Yes
+# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
+jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.tcpLower=
+jck.env.runtime.net.tcpRange=No
+jck.env.runtime.net.tcpUpper=
+jck.env.runtime.net.udpLower=
+jck.env.runtime.net.udpRange=No
+jck.env.runtime.net.udpUpper=
+jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.remoteAgent.loadClasses=No
+jck.env.runtime.remoteAgent.passivePort=
+jck.env.runtime.remoteAgent.passivePortDefault=Yes
+jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
+jck.env.runtime.services.autostartServices=
+jck.env.runtime.services.servicesOn=No
+jck.env.runtime.staticsigtest.supportStaticSigTest=No
+jck.env.runtime.testExecute.activationPortValue=
+jck.env.runtime.testExecute.classpath=command line option
+jck.env.runtime.testExecute.classpathEnv=CLASSPATH
+jck.env.runtime.testExecute.classpathOpt=-classpath \#
+jck.env.runtime.testExecute.jarExecution=Yes
+jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
+jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
+jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
+jck.env.runtime.testExecute.libPath=environment variable
+jck.env.runtime.testExecute.modulepathOpt=-L \#
+jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
+jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
+jck.env.runtime.testExecute.optionSpecification=Yes
+jck.env.runtime.testExecute.otherEnvVars=
+jck.env.runtime.testExecute.otherOpts=
+jck.env.runtime.testExecute.rmiActivationSupport=No
+jck.env.runtime.testExecute.stdActivationPort=Yes
+jck.env.runtime.testExecute.supportIIOP=No
+jck.env.runtime.testExecute.verify=-Xfuture
+# jck.env.runtime.url.ftpURL example: ftp\://xxxx.xxxx.xxxx.com/xxx.txt
+jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck8b/excludes\\jck8b.jtx
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=
+jck.keywords.needKeywords=No
+# jck.knownFailuresList.customFiles example: /jck/jck8b/excludes/jck8b.kfl
+jck.knownFailuresList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.needTests=No
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck9/runtime.jti
+++ b/openjdk.test.jck/config/jck9/runtime.jti
@@ -1,5 +1,5 @@
 #JavaTest Harness Configuration Interview
-DESCRIPTION=
+DESCRIPTION=JCK9 runtime template jti for STF automation
 INTERVIEW=com.sun.jck.interview.JCKParameters
 LOCALE=en_US
 NAME=jck_runtime
@@ -9,100 +9,50 @@ TESTSUITE=will_be_set_by_test_automation_at_run_time
 # WORKDIR example: /home/user/JCK-runtime-9
 WORKDIR=will_be_set_by_test_automation_at_run_time
 jck.concurrency.concurrency=1
-jck.env.compiler.agent.networkClassLoading=No
-jck.env.compiler.agent.passivePort=
-jck.env.compiler.agent.resourcesRemoving=No
-jck.env.compiler.compRefExecute.otherEnvVars=
-jck.env.compiler.compRefExecute.otherOpts=
-jck.env.compiler.rmi.tcpLower=
-jck.env.compiler.rmi.tcpRange=No
-jck.env.compiler.rmi.tcpUpper=
-jck.env.compiler.services.autostartServices=
-jck.env.compiler.services.servicesOn=No
-jck.env.compiler.testCompile.annoProc=-processor \#
-jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
-jck.env.compiler.testCompile.classpath=command line option
-jck.env.compiler.testCompile.classpathOpt=-classpath \#
-jck.env.compiler.testCompile.compilerType=command line tool
-jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=No
-jck.env.compiler.testCompile.defaultCompiler=Yes
-jck.env.compiler.testCompile.otherEnvVars=
-jck.env.compiler.testCompile.otherOpts=
-jck.env.compiler.testCompile.outDirOpt=-d \#
-jck.env.compiler.testCompile.outSrcDirOpt=-s \#
-jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
-jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
-jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
-jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
-jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
-jck.env.compiler.testRmic.classpath=command line option
-jck.env.compiler.testRmic.classpathOpt=-classpath \#
-jck.env.compiler.testRmic.iiopOption=-iiop
-jck.env.compiler.testRmic.otherEnvVars=
-jck.env.compiler.testRmic.otherOpts=
-jck.env.compiler.testRmic.outDirOpt=-d \#
-jck.env.compiler.testRmic.v11Option=-v1.1
-jck.env.compiler.testRmic.v12Option=-v1.2
-jck.env.description=
-jck.env.devtools.agent.networkClassLoading=No
-jck.env.devtools.agent.passivePort=
-jck.env.devtools.agent.resourcesRemoving=No
-jck.env.devtools.jaxb.defaultOperationMode=Yes
-jck.env.devtools.jaxb.needJaxbClasses=No
-jck.env.devtools.jaxb.skipJ2XOptional=Yes
-jck.env.devtools.refExecute.otherEnvVars=
-jck.env.devtools.refExecute.otherOpts=
-jck.env.devtools.scriptEnvVars=
-jck.env.devtools.services.autostartServices=
-jck.env.devtools.services.servicesOn=No
-jck.env.devtools.testExecute.classpath=command line option
-jck.env.devtools.testExecute.classpathEnv=CLASSPATH
-jck.env.devtools.testExecute.classpathOpt=-classpath \#
-jck.env.devtools.testExecute.otherEnvVars=
-jck.env.devtools.testExecute.otherOpts=
+jck.env.description=JCK9 runtime template jti for STF automation
 jck.env.envName=jck_runtime
-jck.env.mode=classpath
-jck.env.modules=
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=\ncompilerModulePathOptionTemplate\=\ncompilerModuleSourcePathOptionTemplate\=\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=--module \#\nvmModulePathOptionTemplate\=--module-path \#\nvmAddModsOptionTemplate\=--add-modules \#[,\#]\n
+jck.env.platform=jre
+jck.env.platformModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
 jck.env.product=runtime
-jck.env.profile=4
 jck.env.runtime.RemoteAgent=Yes
 jck.env.runtime.agent.networkClassLoading=No
 jck.env.runtime.agent.passivePort=
 jck.env.runtime.agent.resourcesRemoving=No
-jck.env.runtime.audio=Yes
 jck.env.runtime.audio.canPlayMidi=Yes
 jck.env.runtime.audio.canPlaySound=Yes
 jck.env.runtime.audio.canRecordSound=Yes
 jck.env.runtime.audio.soundURLChoice=Yes
 jck.env.runtime.audio.soundURLYesJCK=.WAV
-jck.env.runtime.awt=Yes
+jck.env.runtime.audio=Yes
 jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
 jck.env.runtime.awt.robotAvailable=Yes
 jck.env.runtime.awt.splashScreenOpt=-splash\:\#
 jck.env.runtime.awt.splashScreenSupported=Yes
-jck.env.runtime.fp=Yes
+jck.env.runtime.awt=Yes
 jck.env.runtime.fp.doubleMaxExponent=
 jck.env.runtime.fp.doubleMinExponent=
 jck.env.runtime.fp.floatMaxExponent=
 jck.env.runtime.fp.floatMinExponent=
 jck.env.runtime.fp.format=Intel, 15 bit exponent
 jck.env.runtime.fp.supportExtended=Yes
+jck.env.runtime.fp=Yes
 jck.env.runtime.ftpSupport=Yes
-jck.env.runtime.idl=Yes
 # jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
 jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.idl.orbPort=9876
-jck.env.runtime.jaas=Yes
+jck.env.runtime.idl=Yes
 jck.env.runtime.jaas.authPolicy=standard system property
 jck.env.runtime.jaas.loginConfig=standard system property
-jck.env.runtime.jdwp=Yes
+jck.env.runtime.jaas=Yes
 jck.env.runtime.jdwp.VMSuspended=Yes
 jck.env.runtime.jdwp.connectorType=attaching
-jck.env.runtime.jdwp.jdwpOpts=-agentlib\:jdwp\=server\=y,transport\=dt_socket,address\=Localhost\:35000,suspend\=y
+jck.env.runtime.jdwp.jdwpOpts=-agentlib\:jdwp\=server\=y,transport\=dt_socket,address\=localhost\:35000,suspend\=y
 jck.env.runtime.jdwp.jdwpSupported=Yes
-jck.env.runtime.jdwp.transportAddress=Localhost\:35000
+jck.env.runtime.jdwp.transportAddress=localhost\:35000
 jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
-jck.env.runtime.jgss=Yes
+jck.env.runtime.jdwp=Yes
 jck.env.runtime.jgss.kdc=No
 # jck.env.runtime.jgss.kdcHostName example: xxxx.xxxx.xxxx.com
 jck.env.runtime.jgss.kdcHostName=will_be_set_by_test_automation_at_run_time
@@ -118,16 +68,16 @@ jck.env.runtime.jgss.krb5ServerPassword=will_be_set_by_test_automation_at_run_ti
 # jck.env.runtime.jgss.krb5ServerUsername example: user1
 jck.env.runtime.jgss.krb5ServerUsername=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.jgss.loginModule=Yes
-jck.env.runtime.jplis=Yes
-jck.env.runtime.jplis.jplisCmdLine=No
-jck.env.runtime.jplis.jplisLivePhase=No
+jck.env.runtime.jgss=Yes
+jck.env.runtime.jplis.jplisCmdLine=Yes
+jck.env.runtime.jplis.jplisLivePhase=Yes
 jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
-jck.env.runtime.jsse=Yes
+jck.env.runtime.jplis=Yes
 jck.env.runtime.jsse.isJKSSupported=Yes
-jck.env.runtime.memory=Yes
+jck.env.runtime.jsse=Yes
 jck.env.runtime.memory.expectOutOfMemory=Yes
 jck.env.runtime.memory.memoryAllocation=Yes
-jck.env.runtime.net=Yes
+jck.env.runtime.memory=Yes
 # jck.env.runtime.net.localHostIPAddr example: n.n.n.n
 jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
 # jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
@@ -147,8 +97,9 @@ jck.env.runtime.net.testHost2Name=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.net.udpLower=
 jck.env.runtime.net.udpRange=No
 jck.env.runtime.net.udpUpper=
-jck.env.runtime.print=Yes
+jck.env.runtime.net=Yes
 jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.print=Yes
 jck.env.runtime.remoteAgent.loadClasses=No
 jck.env.runtime.remoteAgent.passiveHost=localhost
 jck.env.runtime.remoteAgent.passivePort=
@@ -156,16 +107,12 @@ jck.env.runtime.remoteAgent.passivePortDefault=Yes
 jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
 jck.env.runtime.services.autostartServices=RMI_service ORB_service Distributed_Agent
 jck.env.runtime.services.servicesOn=No
-jck.env.runtime.staticsigtest=Yes
-# jck.env.runtime.staticsigtest.staticSigTestClasspath example: = /home/user/jdk-9/lib
-jck.env.runtime.staticsigtest.staticSigTestClasspath=will_be_set_by_test_automation_at_run_time
-jck.env.runtime.staticsigtest.supportStaticSigTest=Yes
 jck.env.runtime.testExecute.activationPortValue=
 jck.env.runtime.testExecute.additionalClasspath=
 jck.env.runtime.testExecute.classpath=command line option
 jck.env.runtime.testExecute.classpathEnv=CLASSPATH
 jck.env.runtime.testExecute.classpathOpt=-classpath \#
-# jck.env.runtime.testExecute.cmdAsFile example: /home/user/jdk-9/bin/java
+# jck.env.runtime.testExecute.cmdAsFile example: /home/user/jdk9/jre/bin/java
 jck.env.runtime.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.testExecute.jarExecution=Yes
 jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
@@ -175,11 +122,12 @@ jck.env.runtime.testExecute.jmxResourcePathFileValue=will_be_set_by_test_automat
 jck.env.runtime.testExecute.jni=Yes
 jck.env.runtime.testExecute.jvmti=Yes
 jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
-jck.env.runtime.testExecute.jvmtiLivePhase=No
+jck.env.runtime.testExecute.jvmtiLivePhase=Yes
 jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
 jck.env.runtime.testExecute.libPath=environment variable
-jck.env.runtime.testExecute.libPathEnv=LD_LIBRARY_PATH
-jck.env.runtime.testExecute.modulepathOpt=-L \#
+# jck.env.runtime.testExecute.libPathEnv example: LD_LIBRARY_PATH
+jck.env.runtime.testExecute.libPathEnv=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.moduleOptions=Yes
 # jck.env.runtime.testExecute.nativeLibPathFileValue example: /jck/jck9/natives/linux_x86-64
 jck.env.runtime.testExecute.nativeLibPathFileValue=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
@@ -190,14 +138,14 @@ jck.env.runtime.testExecute.otherOpts=
 jck.env.runtime.testExecute.rmi=Yes
 jck.env.runtime.testExecute.rmiActivationSupport=Yes
 jck.env.runtime.testExecute.stdActivationPort=Yes
-jck.env.runtime.testExecute.supportIIOP=Yes
 jck.env.runtime.testExecute.verify=-Xfuture
-jck.env.runtime.url=Yes
 # jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
 jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
 # jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
 jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
 # jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.url=Yes
 jck.env.simpleOrAdvanced=advanced
 # jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
 jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
@@ -216,21 +164,21 @@ jck.env.testPlatform.typecheckerSpecific=Yes
 jck.env.testPlatform.useAgent=No
 # jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
 jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
-jck.excludeList.excludeListType=custom
 jck.excludeList.latestAutoCheck=No
 jck.excludeList.latestAutoCheckInterval=7
 jck.excludeList.latestAutoCheckMode=everyXDays
 jck.excludeList.needExcludeList=Yes
-jck.keywords.keywords=\!interactive&\!jvmtilivephase
 jck.keywords.keywords.mode=expr
-jck.keywords.keywords.value=\!interactive&\!jvmtilivephase
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
 jck.keywords.needKeywords=Yes
-# jck.knownFailuresList.customFiles example: /jck/jck9/excludes/jck9.kfl
 jck.knownFailuresList.customFiles=
 jck.knownFailuresList.needKfl=No
 jck.priorStatus.needStatus=No
 jck.priorStatus.status=
+jck.tests.chooseTests=Yes
 jck.tests.needTests=No
+jck.tests.setOfModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
 jck.tests.tests=
 jck.tests.treeOrFile=tree
 jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck9/runtime.jti
+++ b/openjdk.test.jck/config/jck9/runtime.jti
@@ -1,0 +1,236 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_runtime
+QUESTION=jck.end
+# TESTSUITE example: /jck/jck9/JCK-runtime-9
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-runtime-9
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.compiler.agent.networkClassLoading=No
+jck.env.compiler.agent.passivePort=
+jck.env.compiler.agent.resourcesRemoving=No
+jck.env.compiler.compRefExecute.otherEnvVars=
+jck.env.compiler.compRefExecute.otherOpts=
+jck.env.compiler.rmi.tcpLower=
+jck.env.compiler.rmi.tcpRange=No
+jck.env.compiler.rmi.tcpUpper=
+jck.env.compiler.services.autostartServices=
+jck.env.compiler.services.servicesOn=No
+jck.env.compiler.testCompile.annoProc=-processor \#
+jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
+jck.env.compiler.testCompile.classpath=command line option
+jck.env.compiler.testCompile.classpathOpt=-classpath \#
+jck.env.compiler.testCompile.compilerType=command line tool
+jck.env.compiler.testCompile.compilerstaticsigtest.supportCompilerStaticSigTest=No
+jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.otherEnvVars=
+jck.env.compiler.testCompile.otherOpts=
+jck.env.compiler.testCompile.outDirOpt=-d \#
+jck.env.compiler.testCompile.outSrcDirOpt=-s \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=environment variable
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
+jck.env.compiler.testRmic.classpath=command line option
+jck.env.compiler.testRmic.classpathOpt=-classpath \#
+jck.env.compiler.testRmic.iiopOption=-iiop
+jck.env.compiler.testRmic.otherEnvVars=
+jck.env.compiler.testRmic.otherOpts=
+jck.env.compiler.testRmic.outDirOpt=-d \#
+jck.env.compiler.testRmic.v11Option=-v1.1
+jck.env.compiler.testRmic.v12Option=-v1.2
+jck.env.description=
+jck.env.devtools.agent.networkClassLoading=No
+jck.env.devtools.agent.passivePort=
+jck.env.devtools.agent.resourcesRemoving=No
+jck.env.devtools.jaxb.defaultOperationMode=Yes
+jck.env.devtools.jaxb.needJaxbClasses=No
+jck.env.devtools.jaxb.skipJ2XOptional=Yes
+jck.env.devtools.refExecute.otherEnvVars=
+jck.env.devtools.refExecute.otherOpts=
+jck.env.devtools.scriptEnvVars=
+jck.env.devtools.services.autostartServices=
+jck.env.devtools.services.servicesOn=No
+jck.env.devtools.testExecute.classpath=command line option
+jck.env.devtools.testExecute.classpathEnv=CLASSPATH
+jck.env.devtools.testExecute.classpathOpt=-classpath \#
+jck.env.devtools.testExecute.otherEnvVars=
+jck.env.devtools.testExecute.otherOpts=
+jck.env.envName=jck_runtime
+jck.env.mode=classpath
+jck.env.modules=
+jck.env.product=runtime
+jck.env.profile=4
+jck.env.runtime.RemoteAgent=Yes
+jck.env.runtime.agent.networkClassLoading=No
+jck.env.runtime.agent.passivePort=
+jck.env.runtime.agent.resourcesRemoving=No
+jck.env.runtime.audio=Yes
+jck.env.runtime.audio.canPlayMidi=Yes
+jck.env.runtime.audio.canPlaySound=Yes
+jck.env.runtime.audio.canRecordSound=Yes
+jck.env.runtime.audio.soundURLChoice=Yes
+jck.env.runtime.audio.soundURLYesJCK=.WAV
+jck.env.runtime.awt=Yes
+jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
+jck.env.runtime.awt.robotAvailable=Yes
+jck.env.runtime.awt.splashScreenOpt=-splash\:\#
+jck.env.runtime.awt.splashScreenSupported=Yes
+jck.env.runtime.fp=Yes
+jck.env.runtime.fp.doubleMaxExponent=
+jck.env.runtime.fp.doubleMinExponent=
+jck.env.runtime.fp.floatMaxExponent=
+jck.env.runtime.fp.floatMinExponent=
+jck.env.runtime.fp.format=Intel, 15 bit exponent
+jck.env.runtime.fp.supportExtended=Yes
+jck.env.runtime.ftpSupport=Yes
+jck.env.runtime.idl=Yes
+# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
+jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.idl.orbPort=9876
+jck.env.runtime.jaas=Yes
+jck.env.runtime.jaas.authPolicy=standard system property
+jck.env.runtime.jaas.loginConfig=standard system property
+jck.env.runtime.jdwp=Yes
+jck.env.runtime.jdwp.VMSuspended=Yes
+jck.env.runtime.jdwp.connectorType=attaching
+jck.env.runtime.jdwp.jdwpOpts=-agentlib\:jdwp\=server\=y,transport\=dt_socket,address\=Localhost\:35000,suspend\=y
+jck.env.runtime.jdwp.jdwpSupported=Yes
+jck.env.runtime.jdwp.transportAddress=Localhost\:35000
+jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
+jck.env.runtime.jgss=Yes
+jck.env.runtime.jgss.kdc=No
+# jck.env.runtime.jgss.kdcHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.jgss.kdcHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jgss.kdcRealm=No
+# jck.env.runtime.jgss.kdcRealmName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.jgss.kdcRealmName=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ClientPassword example: password2
+jck.env.runtime.jgss.krb5ClientPassword=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ClientUsername example: user2
+jck.env.runtime.jgss.krb5ClientUsername=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ServerPassword example: password1
+jck.env.runtime.jgss.krb5ServerPassword=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ServerUsername example: user1
+jck.env.runtime.jgss.krb5ServerUsername=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jgss.loginModule=Yes
+jck.env.runtime.jplis=Yes
+jck.env.runtime.jplis.jplisCmdLine=No
+jck.env.runtime.jplis.jplisLivePhase=No
+jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
+jck.env.runtime.jsse=Yes
+jck.env.runtime.jsse.isJKSSupported=Yes
+jck.env.runtime.memory=Yes
+jck.env.runtime.memory.expectOutOfMemory=Yes
+jck.env.runtime.memory.memoryAllocation=Yes
+jck.env.runtime.net=Yes
+# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
+jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.other=Yes
+jck.env.runtime.net.tcpLower=
+jck.env.runtime.net.tcpRange=No
+jck.env.runtime.net.tcpUpper=
+# jck.env.runtime.net.testHost1IPAddr example: n.n.n.n
+jck.env.runtime.net.testHost1IPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost1Name example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.testHost1Name=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost2IPAddr example: n.n.n.n
+jck.env.runtime.net.testHost2IPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost2Name example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.testHost2Name=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.udpLower=
+jck.env.runtime.net.udpRange=No
+jck.env.runtime.net.udpUpper=
+jck.env.runtime.print=Yes
+jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.remoteAgent.loadClasses=No
+jck.env.runtime.remoteAgent.passiveHost=localhost
+jck.env.runtime.remoteAgent.passivePort=
+jck.env.runtime.remoteAgent.passivePortDefault=Yes
+jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
+jck.env.runtime.services.autostartServices=RMI_service ORB_service Distributed_Agent
+jck.env.runtime.services.servicesOn=No
+jck.env.runtime.staticsigtest=Yes
+# jck.env.runtime.staticsigtest.staticSigTestClasspath example: = /home/user/jdk-9/lib
+jck.env.runtime.staticsigtest.staticSigTestClasspath=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.staticsigtest.supportStaticSigTest=Yes
+jck.env.runtime.testExecute.activationPortValue=
+jck.env.runtime.testExecute.additionalClasspath=
+jck.env.runtime.testExecute.classpath=command line option
+jck.env.runtime.testExecute.classpathEnv=CLASSPATH
+jck.env.runtime.testExecute.classpathOpt=-classpath \#
+# jck.env.runtime.testExecute.cmdAsFile example: /home/user/jdk-9/bin/java
+jck.env.runtime.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.jarExecution=Yes
+jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
+jck.env.runtime.testExecute.jmx=Yes
+# jck.env.runtime.testExecute.jmxResourcePathFileValue example: /jck/jck9/natives/linux_x86-64
+jck.env.runtime.testExecute.jmxResourcePathFileValue=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.jni=Yes
+jck.env.runtime.testExecute.jvmti=Yes
+jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
+jck.env.runtime.testExecute.jvmtiLivePhase=No
+jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
+jck.env.runtime.testExecute.libPath=environment variable
+jck.env.runtime.testExecute.libPathEnv=LD_LIBRARY_PATH
+jck.env.runtime.testExecute.modulepathOpt=-L \#
+# jck.env.runtime.testExecute.nativeLibPathFileValue example: /jck/jck9/natives/linux_x86-64
+jck.env.runtime.testExecute.nativeLibPathFileValue=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
+jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
+jck.env.runtime.testExecute.optionSpecification=Yes
+jck.env.runtime.testExecute.otherEnvVars=
+jck.env.runtime.testExecute.otherOpts=
+jck.env.runtime.testExecute.rmi=Yes
+jck.env.runtime.testExecute.rmiActivationSupport=Yes
+jck.env.runtime.testExecute.stdActivationPort=Yes
+jck.env.runtime.testExecute.supportIIOP=Yes
+jck.env.runtime.testExecute.verify=-Xfuture
+jck.env.runtime.url=Yes
+# jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
+jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
+jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+# jck.env.testPlatform.systemRoot example: C\:\\WINDOWS
+jck.env.testPlatform.systemRoot=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords=\!interactive&\!jvmtilivephase
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=\!interactive&\!jvmtilivephase
+jck.keywords.needKeywords=Yes
+# jck.knownFailuresList.customFiles example: /jck/jck9/excludes/jck9.kfl
+jck.knownFailuresList.customFiles=
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.needTests=No
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/include/test_targets.mk
+++ b/openjdk.test.jck/include/test_targets.mk
@@ -22,7 +22,7 @@
 # The default is to look fro a directory called 'default'.
 JCK_CONFIG=default
 
-# Targets to run the JCK
+# Targets to run jck8b
 
 # Targets for the jck8b runtime test suite
 JCK8B_RUNTIME_TESTS:= \
@@ -1369,6 +1369,1373 @@ test.jck8b.devtools.schema_bind.bind_schemaBindings:
 	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_schemaBindings,jckversion=jck8b,testsuite=DEVTOOLS" $(LOG)
 	echo Target $@ completed
 
+# Targets to run jck9
+
+# Targets for the jck9 runtime test suite
+JCK9_RUNTIME_TESTS:= \
+test.jck9.runtime.api.java_math \
+test.jck9.runtime.api.java_security \
+test.jck9.runtime.api.java_sql \
+test.jck9.runtime.api.java_text \
+test.jck9.runtime.api.javax_activation \
+test.jck9.runtime.api.javax_activity \
+test.jck9.runtime.api.javax_annotation \
+test.jck9.runtime.api.javax_crypto \
+test.jck9.runtime.api.javax_imageio \
+test.jck9.runtime.api.javax_lang \
+test.jck9.runtime.api.javax_net \
+test.jck9.runtime.api.javax_script \
+test.jck9.runtime.api.javax_security \
+test.jck9.runtime.api.javax_sql \
+test.jck9.runtime.api.javax_tools \
+test.jck9.runtime.api.javax_transaction \
+test.jck9.runtime.api.org_w3c \
+test.jck9.runtime.api.org_xml \
+test.jck9.runtime.api.serializabletypes \
+test.jck9.runtime.api.signaturetest \
+test.jck9.runtime.api.xinclude \
+test.jck9.runtime.api.xsl \
+test.jck9.runtime.api.java_applet \
+test.jck9.runtime.api.java_awt \
+test.jck9.runtime.api.java_beans \
+test.jck9.runtime.api.java_io \
+test.jck9.runtime.api.java_util \
+test.jck9.runtime.api.javax_accessibility \
+test.jck9.runtime.api.javax_naming \
+test.jck9.runtime.api.javax_print \
+test.jck9.runtime.api.javax_sound \
+test.jck9.runtime.api.javax_swing \
+test.jck9.runtime.api.java_lang \
+test.jck9.runtime.api.java_net \
+test.jck9.runtime.api.java_nio \
+test.jck9.runtime.api.java_rmi \
+test.jck9.runtime.api.javax_management \
+test.jck9.runtime.api.javax_rmi \
+test.jck9.runtime.api.javax_xml \
+test.jck9.runtime.api.modulegraph \
+test.jck9.runtime.api.org_omg \
+test.jck9.runtime.api.org_ietf \
+test.jck9.runtime.api.java_time \
+test.jck9.runtime.vm.cldc \
+test.jck9.runtime.vm.concepts \
+test.jck9.runtime.vm.constantpool \
+test.jck9.runtime.vm.fp \
+test.jck9.runtime.vm.jvmti \
+test.jck9.runtime.vm.module \
+test.jck9.runtime.vm.overview \
+test.jck9.runtime.vm.typechecker \
+test.jck9.runtime.vm.classfmt \
+test.jck9.runtime.vm.instr \
+test.jck9.runtime.vm.jni \
+test.jck9.runtime.vm.jdwp \
+test.jck9.runtime.xopts.vm.cldc \
+test.jck9.runtime.xopts.vm.concepts \
+test.jck9.runtime.xopts.vm.constantpool \
+test.jck9.runtime.xopts.vm.fp \
+test.jck9.runtime.xopts.vm.jvmti \
+test.jck9.runtime.xopts.vm.overview \
+test.jck9.runtime.xopts.vm.typechecker \
+test.jck9.runtime.xopts.vm.classfmt \
+test.jck9.runtime.xopts.vm.instr \
+test.jck9.runtime.xopts.vm.jni \
+test.jck9.runtime.xopts.vm.jdwp \
+test.jck9.runtime.lang.ANNOT \
+test.jck9.runtime.lang.ARR \
+test.jck9.runtime.lang.BINC \
+test.jck9.runtime.lang.CLSS \
+test.jck9.runtime.lang.CONV \
+test.jck9.runtime.lang.DASG \
+test.jck9.runtime.lang.EXCP \
+test.jck9.runtime.lang.EXEC \
+test.jck9.runtime.lang.EXPR \
+test.jck9.runtime.lang.FP \
+test.jck9.runtime.lang.ICLS \
+test.jck9.runtime.lang.INTF \
+test.jck9.runtime.lang.LEX \
+test.jck9.runtime.lang.NAME \
+test.jck9.runtime.lang.PKGS \
+test.jck9.runtime.lang.STMT \
+test.jck9.runtime.lang.THRD \
+test.jck9.runtime.lang.TYPE \
+test.jck9.runtime.lang.INFR \
+test.jck9.runtime.lang.LMBD \
+test.jck9.runtime.xml_schema.msdata.additional \
+test.jck9.runtime.xml_schema.msdata.annotations \
+test.jck9.runtime.xml_schema.msdata.attribute \
+test.jck9.runtime.xml_schema.msdata.attributeGroup \
+test.jck9.runtime.xml_schema.msdata.complexType \
+test.jck9.runtime.xml_schema.msdata.datatypes \
+test.jck9.runtime.xml_schema.msdata.element \
+test.jck9.runtime.xml_schema.msdata.errata10 \
+test.jck9.runtime.xml_schema.msdata.group \
+test.jck9.runtime.xml_schema.msdata.identityConstraint \
+test.jck9.runtime.xml_schema.msdata.modelGroups \
+test.jck9.runtime.xml_schema.msdata.notations \
+test.jck9.runtime.xml_schema.msdata.particles \
+test.jck9.runtime.xml_schema.msdata.regex \
+test.jck9.runtime.xml_schema.msdata.schema \
+test.jck9.runtime.xml_schema.msdata.simpleType \
+test.jck9.runtime.xml_schema.msdata.wildcards \
+test.jck9.runtime.xml_schema.nistdata.atomic \
+test.jck9.runtime.xml_schema.nistdata.list \
+test.jck9.runtime.xml_schema.nistdata.union \
+test.jck9.runtime.xml_schema.sundata \
+test.jck9.runtime.xml_schema.boeingData
+# Allow the user to exclude tests from the command line
+JCK9_RUNTIME_TESTS:=$(filter-out $(EXCLUDE),$(JCK9_RUNTIME_TESTS))
+
+JCK9_TESTS_REQUIRING_CONFIG:=\
+test.jck9.runtime.api.java_net \
+test.jck9.runtime.api.java_nio \
+test.jck9.runtime.api.org_ietf \
+test.jck9.runtime.api.javax_security
+# Allow the user to exclude tests from the command line
+JCK9_TESTS_REQUIRING_CONFIG:=$(filter-out $(EXCLUDE),$(JCK9_TESTS_REQUIRING_CONFIG))
+
+JCK9_TESTS_NO_CONFIG:=$(filter-out $(JCK9_TESTS_REQUIRING_CONFIG),$(JCK9_TESTS))
+# Allow the user to exclude tests from the command line
+JCK9_TESTS_NO_CONFIG:=$(filter-out $(EXCLUDE),$(JCK9_TESTS_NO_CONFIG))
+
+JCK9_RUNTIME_TESTS_NO_CONFIG:=$(filter-out $(JCK9_TESTS_REQUIRING_CONFIG),$(JCK9_RUNTIME_TESTS))
+# Allow the user to exclude tests from the command line
+JCK9_RUNTIME_TESTS_NO_CONFIG:=$(filter-out $(EXCLUDE),$(JCK9_RUNTIME_TESTS_NO_CONFIG))
+
+# Targets for the jck9 compiler test suite
+JCK9_COMPILER_TESTS:= \
+test.jck9.compiler.api.java_rmi \
+test.jck9.compiler.api.javax_annotation \
+test.jck9.compiler.api.javax_lang \
+test.jck9.compiler.api.javax_tools \
+test.jck9.compiler.api.signaturetest \
+test.jck9.compiler.lang.ANNOT \
+test.jck9.compiler.lang.ARR  \
+test.jck9.compiler.lang.BINC  \
+test.jck9.compiler.lang.CLSS  \
+test.jck9.compiler.lang.CONV  \
+test.jck9.compiler.lang.DASG  \
+test.jck9.compiler.lang.EXCP  \
+test.jck9.compiler.lang.EXEC  \
+test.jck9.compiler.lang.EXPR  \
+test.jck9.compiler.lang.FP  \
+test.jck9.compiler.lang.ICLS  \
+test.jck9.compiler.lang.INTF  \
+test.jck9.compiler.lang.LEX  \
+test.jck9.compiler.lang.NAME  \
+test.jck9.compiler.lang.PKGS  \
+test.jck9.compiler.lang.STMT  \
+test.jck9.compiler.lang.THRD  \
+test.jck9.compiler.lang.TYPE \
+test.jck9.compiler.lang.INFR \
+test.jck9.compiler.lang.LMBD \
+test.jck9.compiler.lang.MOD
+# Allow the user to exclude tests from the command line
+JCK9_COMPILER_TESTS:=$(filter-out $(EXCLUDE),$(JCK9_COMPILER_TESTS))
+
+# Targets for the jck9 devtools test suite
+JCK9_DEVTOOLS_TESTS:= \
+test.jck9.devtools.java2schema \
+test.jck9.devtools.xml_schema.msData.additional \
+test.jck9.devtools.xml_schema.msData.annotations \
+test.jck9.devtools.xml_schema.msData.attribute  \
+test.jck9.devtools.xml_schema.msData.attributeGroup \
+test.jck9.devtools.xml_schema.msData.complexType  \
+test.jck9.devtools.xml_schema.msData.datatypes  \
+test.jck9.devtools.xml_schema.msData.element  \
+test.jck9.devtools.xml_schema.msData.errata10  \
+test.jck9.devtools.xml_schema.msData.group  \
+test.jck9.devtools.xml_schema.msData.identityConstraint  \
+test.jck9.devtools.xml_schema.msData.modelGroups  \
+test.jck9.devtools.xml_schema.msData.notations  \
+test.jck9.devtools.xml_schema.msData.particles  \
+test.jck9.devtools.xml_schema.msData.regex  \
+test.jck9.devtools.xml_schema.msData.schema \
+test.jck9.devtools.xml_schema.msData.simpleType  \
+test.jck9.devtools.xml_schema.msData.wildcards \
+test.jck9.devtools.xml_schema.nistData.atomic.anyURI \
+test.jck9.devtools.xml_schema.nistData.atomic.base64Binary   \
+test.jck9.devtools.xml_schema.nistData.atomic.boolean \
+test.jck9.devtools.xml_schema.nistData.atomic.byte \
+test.jck9.devtools.xml_schema.nistData.atomic.date \
+test.jck9.devtools.xml_schema.nistData.atomic.dateTime   \
+test.jck9.devtools.xml_schema.nistData.atomic.decimal   \
+test.jck9.devtools.xml_schema.nistData.atomic.double \
+test.jck9.devtools.xml_schema.nistData.atomic.duration   \
+test.jck9.devtools.xml_schema.nistData.atomic.float \
+test.jck9.devtools.xml_schema.nistData.atomic.gDay \
+test.jck9.devtools.xml_schema.nistData.atomic.gMonth   \
+test.jck9.devtools.xml_schema.nistData.atomic.gMonthDay \
+test.jck9.devtools.xml_schema.nistData.atomic.gYear \
+test.jck9.devtools.xml_schema.nistData.atomic.gYearMonth \
+test.jck9.devtools.xml_schema.nistData.atomic.hexBinary \
+test.jck9.devtools.xml_schema.nistData.atomic.ID \
+test.jck9.devtools.xml_schema.nistData.atomic.int \
+test.jck9.devtools.xml_schema.nistData.atomic.integer \
+test.jck9.devtools.xml_schema.nistData.atomic.language \
+test.jck9.devtools.xml_schema.nistData.atomic.long \
+test.jck9.devtools.xml_schema.nistData.atomic.Name \
+test.jck9.devtools.xml_schema.nistData.atomic.NCName \
+test.jck9.devtools.xml_schema.nistData.atomic.negativeInteger \
+test.jck9.devtools.xml_schema.nistData.atomic.NMTOKEN   \
+test.jck9.devtools.xml_schema.nistData.atomic.nonNegativeInteger \
+test.jck9.devtools.xml_schema.nistData.atomic.nonPositiveInteger   \
+test.jck9.devtools.xml_schema.nistData.atomic.normalizedString \
+test.jck9.devtools.xml_schema.nistData.atomic.positiveInteger   \
+test.jck9.devtools.xml_schema.nistData.atomic.QName \
+test.jck9.devtools.xml_schema.nistData.atomic.short \
+test.jck9.devtools.xml_schema.nistData.atomic.string \
+test.jck9.devtools.xml_schema.nistData.atomic.time \
+test.jck9.devtools.xml_schema.nistData.atomic.token \
+test.jck9.devtools.xml_schema.nistData.atomic.unsignedByte \
+test.jck9.devtools.xml_schema.nistData.atomic.unsignedInt  \
+test.jck9.devtools.xml_schema.nistData.atomic.unsignedLong \
+test.jck9.devtools.xml_schema.nistData.atomic.unsignedShort \
+test.jck9.devtools.xml_schema.nistData.list.anyURI \
+test.jck9.devtools.xml_schema.nistData.list.base64Binary \
+test.jck9.devtools.xml_schema.nistData.list.boolean \
+test.jck9.devtools.xml_schema.nistData.list.byte \
+test.jck9.devtools.xml_schema.nistData.list.date \
+test.jck9.devtools.xml_schema.nistData.list.dateTime \
+test.jck9.devtools.xml_schema.nistData.list.decimal \
+test.jck9.devtools.xml_schema.nistData.list.double \
+test.jck9.devtools.xml_schema.nistData.list.duration \
+test.jck9.devtools.xml_schema.nistData.list.float \
+test.jck9.devtools.xml_schema.nistData.list.gDay   \
+test.jck9.devtools.xml_schema.nistData.list.gMonth   \
+test.jck9.devtools.xml_schema.nistData.list.gMonthDay   \
+test.jck9.devtools.xml_schema.nistData.list.gYear \
+test.jck9.devtools.xml_schema.nistData.list.gYearMonth \
+test.jck9.devtools.xml_schema.nistData.list.hexBinary  \
+test.jck9.devtools.xml_schema.nistData.list.ID  \
+test.jck9.devtools.xml_schema.nistData.list.int \
+test.jck9.devtools.xml_schema.nistData.list.integer   \
+test.jck9.devtools.xml_schema.nistData.list.language   \
+test.jck9.devtools.xml_schema.nistData.list.long \
+test.jck9.devtools.xml_schema.nistData.list.Name      \
+test.jck9.devtools.xml_schema.nistData.list.NCName \
+test.jck9.devtools.xml_schema.nistData.list.negativeInteger  \
+test.jck9.devtools.xml_schema.nistData.list.NMTOKEN \
+test.jck9.devtools.xml_schema.nistData.list.NMTOKENS \
+test.jck9.devtools.xml_schema.nistData.list.nonNegativeInteger  \
+test.jck9.devtools.xml_schema.nistData.list.nonPositiveInteger  \
+test.jck9.devtools.xml_schema.nistData.list.normalizedString \
+test.jck9.devtools.xml_schema.nistData.list.positiveInteger \
+test.jck9.devtools.xml_schema.nistData.list.QName   \
+test.jck9.devtools.xml_schema.nistData.list.short \
+test.jck9.devtools.xml_schema.nistData.list.string \
+test.jck9.devtools.xml_schema.nistData.list.time \
+test.jck9.devtools.xml_schema.nistData.list.token \
+test.jck9.devtools.xml_schema.nistData.list.unsignedByte \
+test.jck9.devtools.xml_schema.nistData.list.unsignedInt \
+test.jck9.devtools.xml_schema.nistData.list.unsignedLong \
+test.jck9.devtools.xml_schema.nistData.list.unsignedShort \
+test.jck9.devtools.xml_schema.nistData.union \
+test.jck9.devtools.xml_schema.sunData \
+test.jck9.devtools.xml_schema.boeingData \
+test.jck9.devtools.jaxws \
+test.jck9.devtools.schema2java.nisttest \
+test.jck9.devtools.schema2java.structures \
+test.jck9.devtools.schema_bind.bind_class   \
+test.jck9.devtools.schema_bind.bind_dom \
+test.jck9.devtools.schema_bind.bind_globalBindings \
+test.jck9.devtools.schema_bind.bind_property \
+test.jck9.devtools.schema_bind.bind_factoryMethod \
+test.jck9.devtools.schema_bind.bind_inlineBinaryData \
+test.jck9.devtools.schema_bind.bind_javaType \
+test.jck9.devtools.schema_bind.bind_schemaBindings
+# Allow the user to exclude tests from the command line
+JCK9_DEVTOOLS_TESTS:=$(filter-out $(EXCLUDE),$(JCK9_DEVTOOLS_TESTS))
+
+# All the JCK9 tests
+JCK9_TESTS:=$(JCK9_RUNTIME_TESTS) \
+$(JCK9_COMPILER_TESTS) \
+$(JCK9_DEVTOOLS_TESTS)
+
+.PHONY: \
+test.jck.custom
+
+.PHONY: \
+test.jck9 \
+test.jck9.noconfig \
+test.jck9.compiler.custom \
+test.jck9.compiler.api \
+test.jck9.compiler.lang \
+test.jck9.devtools.custom \
+test.jck9.devtools.java2schema \
+test.jck9.devtools.jaxws \
+test.jck9.devtools.schema2java \
+test.jck9.devtools.schema_bindtest \
+test.jck9.devtools.xml_schema \
+test.jck9.runtime.custom \
+test.jck9.runtime.api \
+test.jck9.runtime.lang \
+test.jck9.runtime.vm \
+test.jck9.runtime.xml_schema \
+test.jck9.runtime.api.in.parts \
+test.jck9.runtime.api.noconfig
+
+# Target to run Java 9 Runtime JCK tests in one run but in smaller parts.
+test.jck9.runtime.api.in.parts: $(JCK9_RUNTIME_TESTS)
+# Target to run Java 9 Runtime JCK tests excluding the parts which require Kerberos and Http server setup
+test.jck9.runtime.api.noconfig: $(JCK9_RUNTIME_TESTS_NO_CONFIG)
+
+# Target to run tests from any JCK test directory
+test.jck.custom:
+	echo Running target $@ with custom jck test $(JCKTEST), jckversion $(JCKVERSION), testsuite $(JCKTESTSUITE)
+	$(STF_COMMAND) -test=Jck -test-args="tests=$(JCKTEST),jckversion=$(JCKVERSION),testsuite=$(JCKTESTSUITE)" $(LOG)
+	echo Target $@ completed
+
+# jck9 targets
+# Targets to run all Java 9 JCK in small parts
+test.jck9: $(JCK9_TESTS)
+# Target to run Java 9 JCK tests excluding the parts which require Kerberos and Http server setup
+test.jck9.noconfig: $(JCK9_TESTS_NO_CONFIG)
+
+# Targets to run tests from any jck9 runtime, compiler or devtools test directory
+test.jck9.runtime.custom:
+	echo Running target $@ with custom jck test ${JCKTEST}
+	$(STF_COMMAND) -test=Jck -test-args="tests=${JCKTEST},jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.custom:
+	echo Running target $@ with custom jck test ${JCKTEST}
+	$(STF_COMMAND) -test=Jck -test-args="tests=${JCKTEST},jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.custom:
+	echo Running target $@ with custom jck test ${JCKTEST}
+	$(STF_COMMAND) -test=Jck -test-args="tests=${JCKTEST},jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+
+# Targets to run Java 9 JCK in very large pieces
+test.jck9.runtime.api:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	echo Target $@ completed
+test.jck9.runtime.lang:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	echo Target $@ completed
+test.jck9.runtime.vm:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	echo Target $@ completed
+test.jck9.runtime.xml_schema:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.api:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.java2schema:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=java2schema,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.jaxws:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=jaxws,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema2java:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema2java,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+
+
+# Target to run Java 9 Runtime JCK tests in one run but in smaller parts.
+test.jck9.runtime.api.in.parts: $(JCK9_RUNTIME_TESTS)
+# Target to run Java 9 Runtime JCK tests excluding the parts which require Kerberos and Http server setup
+test.jck9.runtime.api.noconfig: $(JCK9_RUNTIME_TESTS_NO_CONFIG)
+
+# Targets to run runtime test suites individually
+test.jck9.runtime.api.java_math:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_math,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_security:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_security,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_sql:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_sql,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_text:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_text,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_activation:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_activation,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_activity:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_activity,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_annotation:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_annotation,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_crypto:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_crypto,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_imageio:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_imageio,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_lang:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_lang,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_net:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_net,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_script:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_script,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_security:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_security,jckversion=jck9,testsuite=RUNTIME,config=$(JCK_CONFIG)" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_sql:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_sql,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_tools:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_tools,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_transaction:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_transaction,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.org_w3c:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/org_w3c,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.serializabletypes:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/serializabletypes,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.org_xml:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/org_xml,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.signaturetest:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/signaturetest,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.xinclude:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/xinclude,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.xsl:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/xsl,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_applet:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_applet,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_awt:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_awt,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_beans:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_beans,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_io:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_io,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_util:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_util,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_accessibility:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_accessibility,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_naming:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_naming,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_print:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_print,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_sound:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_sound,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_swing:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_swing,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_lang:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_lang,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_net:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_net,jckversion=jck9,testsuite=RUNTIME,config=$(JCK_CONFIG)" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_nio:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_nio,jckversion=jck9,testsuite=RUNTIME,config=$(JCK_CONFIG)" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_rmi:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_rmi,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_management:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_management,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_rmi:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_rmi,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.javax_xml:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_xml,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.modulegraph:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/modulegraph,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.org_omg:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/org_omg,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.org_ietf:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/org_ietf,jckversion=jck9,testsuite=RUNTIME,config=$(JCK_CONFIG)" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.api.java_time:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_time,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.cldc:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/cldc,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.concepts:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/concepts,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.constantpool:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/constantpool,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.fp:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/fp,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.jvmti:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jvmti,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.module:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/module,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.overview:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/overview,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.typechecker:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/typechecker,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.classfmt:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/classfmt,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.instr:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/instr,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.jni:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jni,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.vm.jdwp:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jdwp,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.cldc:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/cldc,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.concepts:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/concepts,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.constantpool:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/constantpool,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.fp:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/fp,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.jvmti:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jvmti,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.overview:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/overview,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.typechecker:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/typechecker,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.classfmt:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/classfmt,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.instr:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/instr,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.jni:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jni,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xopts.vm.jdwp:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jdwp,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.ANNOT:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ANNOT,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.ARR:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ARR,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.BINC :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/BINC,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.CLSS :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/CLSS,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.CONV :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/CONV,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.DASG :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/DASG,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.EXCP :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXCP,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.EXEC :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXEC,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.EXPR :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXPR,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.FP :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/FP,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.ICLS :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ICLS,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.INTF :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/INTF,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.LEX :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/LEX,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.NAME :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/NAME,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.PKGS :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/PKGS,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.STMT :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/STMT,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.THRD :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/THRD,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.TYPE:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/TYPE,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.INFR:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/INFR,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.lang.LMBD:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/LMBD,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.additional:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/additional,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.annotations:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/annotations,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.attribute:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/attribute,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.attributeGroup:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/attributeGroup,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.complexType:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/complexType,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.datatypes:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/datatypes,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.element:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/element,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.errata10:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/errata10,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.group:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/group,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.identityConstraint:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/identityConstraint,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.modelGroups:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/modelGroups,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.notations:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/notations,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.particles:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/particles,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.regex:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/regex,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.schema:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/schema,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.simpleType:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/simpleType,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.msdata.wildcards:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/wildcards,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.nistdata.atomic:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.nistdata.list:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.nistdata.union:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/union,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.sundata:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/sunData,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+test.jck9.runtime.xml_schema.boeingData:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/boeingData,jckversion=jck9,testsuite=RUNTIME" $(LOG)
+	@echo Target $@ completed
+
+# Targets to run compiler test suites individually
+test.jck9.compiler.api.java_rmi:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_rmi,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.api.javax_annotation:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_annotation,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.api.javax_lang:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_lang,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.api.javax_tools:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_tools,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.api.signaturetest:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/signaturetest,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.ANNOT:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ANNOT,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.ARR :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ARR,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.BINC :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/BINC,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.CLSS :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/CLSS,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.CONV :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/CONV,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.DASG :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/DASG,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.EXCP :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXCP,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.EXEC :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXEC,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.EXPR :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXPR,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.FP :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/FP,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.ICLS :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ICLS,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.INTF :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/INTF,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.LEX :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/LEX,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.NAME :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/NAME,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.PKGS :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/PKGS,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.STMT :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/STMT,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.THRD :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/THRD,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.TYPE:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/TYPE,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.INFR:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/INFR,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.LMBD:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/LMBD,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+test.jck9.compiler.lang.MOD:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/MOD,jckversion=jck9,testsuite=COMPILER" $(LOG)
+	echo Target $@ completed
+
+# Targets to run devtools test suites individually
+# java2schema already defined above, not broken down further
+#test.jck9.devtools.java2schema:
+#	echo Running target $@
+#	$(STF_COMMAND) -test=Jck -test-args="tests=java2schema,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+#	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.additional:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/additional,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.annotations:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/annotations,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.attribute :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/attribute,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.attributeGroup:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/attributeGroup,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.complexType :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/complexType,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.datatypes :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/datatypes,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.element :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/element,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.errata10 :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/errata10,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.group :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/group,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.identityConstraint :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/identityConstraint,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.modelGroups :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/modelGroups,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.notations :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/notations,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.particles :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/particles,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.regex :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/regex,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.schema:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/schema,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.simpleType :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/simpleType,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.msData.wildcards:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/wildcards,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.anyURI:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/anyURI,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.base64Binary :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/base64Binary,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.boolean:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/boolean,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.byte:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/byte,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.date:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/date,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.dateTime :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/dateTime,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.decimal :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/decimal,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.double:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/double,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.duration :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/duration,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.float:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/float,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.gDay:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gDay,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.gMonth :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gMonth,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.gMonthDay:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gMonthDay,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.gYear:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gYear,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.gYearMonth:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gYearMonth,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.hexBinary:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/hexBinary,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.ID:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/ID,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.int:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/int,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.integer:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/integer,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.language:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/language,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.long:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/long,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.Name:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/Name,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.NCName:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/NCName,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.negativeInteger:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/negativeInteger,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.NMTOKEN :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/NMTOKEN,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.nonNegativeInteger:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/nonNegativeInteger,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.nonPositiveInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/nonPositiveInteger,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.normalizedString:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/normalizedString,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.positiveInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/positiveInteger,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.QName:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/QName,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.short:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/short,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.string:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/string,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.time:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/time,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.token:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/token,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.unsignedByte:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/unsignedByte,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.unsignedInt :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/unsignedInt,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.unsignedLong:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/unsignedLong,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.atomic.unsignedShort:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/unsignedShort,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.anyURI:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/anyURI,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.base64Binary:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/base64Binary,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.boolean:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/boolean,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.byte:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/byte,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.date:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/date,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.dateTime:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/dateTime,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.decimal:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/decimal,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.double:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/double,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.duration:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/duration,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.float:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/float,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.gDay :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gDay,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.gMonth :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gMonth,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.gMonthDay :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gMonthDay,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.gYear:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gYear,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.gYearMonth:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gYearMonth,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.hexBinary :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/hexBinary,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.ID :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/ID,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.int:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/int,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.integer :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/integer,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.language :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/language,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.long:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/long,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.Name   :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/Name,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.NCName:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/NCName,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.negativeInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/negativeInteger,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.NMTOKEN:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/NMTOKEN,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.NMTOKENS:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/NMTOKENS,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.nonNegativeInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/nonNegativeInteger,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.nonPositiveInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/nonPositiveInteger,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.normalizedString:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/normalizedString,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.positiveInteger:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/positiveInteger,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.QName :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/QName,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.short:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/short,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.string:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/string,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.time:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/time,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.token:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/token,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.unsignedByte:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/unsignedByte,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.unsignedInt:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/unsignedInt,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.unsignedLong:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/unsignedLong,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.list.unsignedShort:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/unsignedShort,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.nistData.union:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/union,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.sunData:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/sunData,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.xml_schema.boeingData:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/boeingData,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+# jaxws already defined above, not broken down further
+#test.jck9.devtools.jaxws:
+#	echo Running target $@
+#	$(STF_COMMAND) -test=Jck -test-args="tests=jaxws,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+#	echo Target $@ completed
+test.jck9.devtools.schema2java.nisttest:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema2java/nisttest,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema2java.structures:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema2java/structures,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind.bind_class :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_class,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind.bind_dom:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_dom,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind.bind_globalBindings:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_globalBindings,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind.bind_property:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_property,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind.bind_factoryMethod:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_factoryMethod,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind.bind_inlineBinaryData:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_inlineBinaryData,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind.bind_javaType:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_javaType,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+test.jck9.devtools.schema_bind.bind_schemaBindings:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_schemaBindings,jckversion=jck9,testsuite=DEVTOOLS" $(LOG)
+	echo Target $@ completed
+
 help.jck:
 	@echo -------------------------------------------------------------------------------
 	@echo Help for JCK tests
@@ -1434,3 +2801,13 @@ help.jcktests:
 	@echo -------------------------------------------------------------------------------
 	@echo The following targets run preset subsets of the jck8b devtools tests
 	@echo $(subst $(SPACE),$(NEWLINE)echo ,$(JCK8B_DEVTOOLS_TESTS))
+	@echo -------------------------------------------------------------------------------
+	@echo The following targets run preset subsets of the jck9 runtime tests
+	@echo $(subst $(SPACE),$(NEWLINE)echo ,$(JCK9_RUNTIME_TESTS))
+	@echo -------------------------------------------------------------------------------
+	@echo The following targets run preset subsets of the jck9 compiler tests
+	@echo $(subst $(SPACE),$(NEWLINE)echo ,$(JCK9_COMPILER_TESTS))
+	@echo -------------------------------------------------------------------------------
+	@echo The following targets run preset subsets of the jck9 devtools tests
+	@echo $(subst $(SPACE),$(NEWLINE)echo ,$(JCK9_DEVTOOLS_TESTS))
+	

--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -1002,10 +1002,10 @@ public class Jck implements StfPluginInterface {
 		String testSpecificJvmOptions = "";
 		// --add-modules options are required to make some modules visible on Java 9
 		if (jckVersion.contains("jck9") ) {
-			if (tests.contains("api/javax_activation") ) {
+			if (tests.contains("api/javax_activation") || tests.contains("api/java_lang")) {
 				testSpecificJvmOptions = "--add-modules java.activation";
 			}
-			if (tests.contains("api/javax_activity") ) {
+			if (tests.contains("api/javax_activity") || tests.contains("api/javax_rmi") || tests.contains("api/org_omg")) {
 				testSpecificJvmOptions = "--add-modules java.corba";
 			}
 			if (tests.contains("api/javax_annotation") ) {
@@ -1019,6 +1019,9 @@ public class Jck implements StfPluginInterface {
 			}
 			if (tests.contains("api/javax_transaction") ) {
 				testSpecificJvmOptions = "--add-modules java.transaction";
+			}
+			if (tests.contains("api/javax_xml") ) {
+				testSpecificJvmOptions = "--add-modules java.xml.bind";
 			}
 		}
 		return testSpecificJvmOptions;

--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -1002,13 +1002,13 @@ public class Jck implements StfPluginInterface {
 		String testSpecificJvmOptions = "";
 		// --add-modules options are required to make some modules visible on Java 9
 		if (jckVersion.contains("jck9") ) {
-			if (tests.contains("api/javax_activation") || tests.contains("api/java_lang")) {
+			if (tests.contains("api/javax_activation")) {
 				testSpecificJvmOptions = "--add-modules java.activation";
 			}
 			if (tests.contains("api/javax_activity") || tests.contains("api/javax_rmi") || tests.contains("api/org_omg")) {
 				testSpecificJvmOptions = "--add-modules java.corba";
 			}
-			if (tests.contains("api/javax_annotation") ) {
+			if (tests.contains("api/javax_annotation") || tests.contains("api/java_lang")) {
 				testSpecificJvmOptions = "--add-modules java.xml.ws.annotation";
 			}
 			if (tests.contains("api/javax_crypto") ) {
@@ -1021,7 +1021,7 @@ public class Jck implements StfPluginInterface {
 				testSpecificJvmOptions = "--add-modules java.transaction";
 			}
 			if (tests.contains("api/javax_xml") ) {
-				testSpecificJvmOptions = "--add-modules java.xml.bind";
+				testSpecificJvmOptions = "--add-modules java.xml";
 			}
 		}
 		return testSpecificJvmOptions;

--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -248,13 +248,13 @@ public class Jck implements StfPluginInterface {
 			throw new StfException(testExecutionType + "with Agent " + withAgent + "combination is not yet supported.");
 		}
 		
-		if (jckVersion.contains("jck9")) {
-			if (testExecutionType.equals("multijvm") && withAgent.equals("off")) {
-				jck9ConfigurationForMultijvmWithNoAgent(test);
-			} else {
-				throw new StfException(testExecutionType + "with Agent " + withAgent + "combination is not yet supported.");
-			}
-		}
+		//if (jckVersion.contains("jck9")) {
+		//	if (testExecutionType.equals("multijvm") && withAgent.equals("off")) {
+		//		jck9ConfigurationForMultijvmWithNoAgent(test);
+		//	} else {
+		//		throw new StfException(testExecutionType + "with Agent " + withAgent + "combination is not yet supported.");
+		//	}
+		//}
 
 		String jtx = "";
 		if ( jtxFile.asJavaFile().exists() ) {

--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -247,14 +247,6 @@ public class Jck implements StfPluginInterface {
 		} else {
 			throw new StfException(testExecutionType + "with Agent " + withAgent + "combination is not yet supported.");
 		}
-		
-		//if (jckVersion.contains("jck9")) {
-		//	if (testExecutionType.equals("multijvm") && withAgent.equals("off")) {
-		//		jck9ConfigurationForMultijvmWithNoAgent(test);
-		//	} else {
-		//		throw new StfException(testExecutionType + "with Agent " + withAgent + "combination is not yet supported.");
-		//	}
-		//}
 
 		String jtx = "";
 		if ( jtxFile.asJavaFile().exists() ) {
@@ -296,6 +288,7 @@ public class Jck implements StfPluginInterface {
 					|| tests.contains("api/org_omg") || tests.contains("api/javax_xml") || tests.contains("vm/jdwp")) ) {
 				javatestAgent = test.doRunBackgroundProcess("Starting javatest agent", "AGNT", ECHO_ON, ExpectedOutcome.neverCompletes(), test.createJavaProcessDefinition()
 						.addJvmOption("-Djavatest.security.allowPropertiesAccess=true -Djava.security.policy=" + test.env().findPrereqFile(jckTopDir + jckVersion + "/" + testSuiteFolder + "/lib/jck.policy").toString())
+						.addJvmOption(" --add-modules java.xml.ws,java.corba")
 						.addJarToClasspath(test.env().findPrereqFile(jckTopDir + jckVersion + "/" + testSuiteFolder + executeJar))
 						.addDirectoryToClasspath(test.env().findPrereqDirectory(jckTopDir + jckVersion + "/" + testSuiteFolder + "/classes"))
 						.runClass("com.sun.javatest.agent.AgentMain")
@@ -405,13 +398,16 @@ public class Jck implements StfPluginInterface {
 	private String getSignatureTestJars(String root) throws Exception {
 		String jarsList = "";
 		StringBuffer sb = new StringBuffer();
+		logger.info("Looking for .jar files in " + root + " for signaturetest.");
 		
 		sb.append(locateFileOrFolder(root,".jar"));
 		
 		String newRoot = root.replaceAll("lib", "bin");
+		logger.info("Looking for vm.jar in " + newRoot + " for signaturetest.");
 		sb.append(locateFileOrFolder(newRoot,"vm.jar"));
 		
 		jarsList = sb.toString();
+		logger.info("Using " + jarsList + " for signaturetest.");
 		return jarsList;
 	}
 		
@@ -469,10 +465,6 @@ public class Jck implements StfPluginInterface {
 				libPath = "LIBPATH";
 				robotAvailable = "No";
 				concurrency = "4";
-				if ( testsRequireDisplay(tests) ) {
-					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
-					fileContent += "set jck.env.runtime.testExecute.otherEnvVars LIBPATH=/usr/lpp/tcpip/X11R66/lib" + ";\n";
-				}
 			} else {
 				throw new StfException("Unknown platform:: " + platform);
 			}
@@ -548,9 +540,14 @@ public class Jck implements StfPluginInterface {
 				fileContent += "set jck.env.runtime.url.ftpURL " + ftpUrl + ";\n";
 				fileContent += "set jck.env.runtime.url.fileURL " + fileUrl + ";\n";
 			}
-			if ( tests.contains("api/java_net") || tests.contains("api/org_omg") || tests.contains("api/javax_management") || tests.contains("api/javax_xml") || tests.contains("vm/jdwp")) {
-				fileContent += "set jck.env.runtime.remoteAgent.passiveHost localhost" + ";\n";
-				fileContent += "set jck.env.runtime.remoteAgent.passivePortDefault Yes" + ";\n";
+			if ( tests.contains("api/java_net") || tests.contains("api/org_omg") || tests.contains("api/javax_management") || tests.contains("api/javax_xml") || tests.contains("vm/jdwp") ) {
+				if ( !tests.contains("api/javax_xml/bind") &&
+					 !tests.contains("api/javax_xml/soap") &&
+					 !tests.contains("api/org_omg/PortableInterceptor") &&
+					 !tests.contains("api/org_omg/PortableServer") ) {
+					fileContent += "set jck.env.runtime.remoteAgent.passiveHost localhost" + ";\n";
+					fileContent += "set jck.env.runtime.remoteAgent.passivePortDefault Yes" + ";\n";
+				}
 			}
 			// Without the following override the following failures occur:
 			// Fatal Error: file:/jck/jck8b/JCK-runtime-8b/tests/api/javax_xml/xmlCore/w3c/ibm/valid/P85/ibm85v01.xml(6,3384): JAXP00010005: The length of entity "[xml]" is "3,381" that exceeds the "1,000" limit set by "FEATURE_SECURE_PROCESSING".
@@ -568,8 +565,10 @@ public class Jck implements StfPluginInterface {
 						testJdk + File.separator + "jre" + File.separator + "lib" + File.separator + "ext";
 				}
 			}
-			if (tests.contains("api/signaturetest")) {
-				fileContent += "set jck.env.runtime.staticsigtest.staticSigTestClasspathRemote \"" + getSignatureTestJars(pathToLib) + "\"" + ";\n";
+			if (jckVersion.contains("jck8b")) {
+				if (tests.contains("api/signaturetest")) {
+					fileContent += "set jck.env.runtime.staticsigtest.staticSigTestClasspathRemote \"" + getSignatureTestJars(pathToLib) + "\"" + ";\n";
+				}
 			}
 			if (extraJvmOptions.contains("nofallback") && tests.startsWith("vm") ) {
 				fileContent += "set jck.env.testPlatform.typecheckerSpecific No" + ";\n";		
@@ -611,23 +610,28 @@ public class Jck implements StfPluginInterface {
 			fileContent += "timeoutfactor 1" + ";\n";							// lang.CLSS,CONV,STMT,INFR requires more than 1h to complete. lang.Annot,EXPR,LMBD require more than 2h to complete tests
 			fileContent += keyword + ";\n";
 			fileContent += "set jck.env.testPlatform.os " + testPlatform + ";\n";
-			fileContent += "set jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsString \"" + pathToJava + "\"" + ";\n";
 			
+			// If the Select Compiler question in the JCK interview was answered as "Java Compiler API (JSR199)",
+			// set jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsString.
+			fileContent += "set jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsString \"" + pathToJava + "\"" + ";\n";
+
+			// If the Select Compiler question in the JCK interview was answered as "command line tool",
+			// set set jck.env.compiler.testCompile.cmdAsString.
+			// fileContent += "set jck.env.compiler.testCompile.cmdAsString \"" + pathToJavac + "\"" + ";\n";
+
+			if (jckVersion.contains("jck8")) {
+				fileContent += "set jck.env.compiler.testCompile.otherOpts \"-source 1.8 \"" + ";\n";
+				if (tests.contains("api/signaturetest")) {
+					fileContent += "set jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspathRemote \"" + getSignatureTestJars(pathToLib) + "\"" + ";\n";
+				}
+			}
+			else {
+				fileContent += "set jck.env.compiler.testCompile.otherOpts \"-source 9 \"" + ";\n";
+			}
 			if (tests.contains("api/java_rmi")) {
 				fileContent += "set jck.env.compiler.testRmic.cmdAsString \"" + pathToRmic + "\"" + ";\n";
 			}
-			
-			if (tests.contains("api/signaturetest")) {
-				fileContent += "set jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspathRemote \"" + getSignatureTestJars(pathToLib) + "\"" + ";\n";
-			}
-			
 			fileContent += "set jck.env.compiler.compRefExecute.cmdAsString \"" + pathToJava + "\"" + ";\n";
-			if (jckVersion.contains("jck8")) {
-				fileContent += "set jck.env.compiler.testCompile.otherOpts \"-source 1.8 \"" + ";\n";
-			}
-			else if (jckVersion.contains("jck9")) {
-				fileContent += "set jck.env.compiler.testCompile.otherOpts \"-source 9 \"" + ";\n";
-			}
 
 			extraJvmOptions += suppressOutOfMemoryDumpOptions;
 			
@@ -687,6 +691,9 @@ public class Jck implements StfPluginInterface {
 			} else {
 				fileContent += "set jck.env.devtools.jaxb.xjcCmd \"" + xjcCmd + "\"" + ";\n";
 			}
+			
+			// Get any additional jvm options for specific tests.
+			extraJvmOptions += getTestSpecificJvmOptions(jckVersion, tests);
 
 			extraJvmOptions += suppressOutOfMemoryDumpOptions;
 			
@@ -694,258 +701,6 @@ public class Jck implements StfPluginInterface {
 			fileContent += "set jck.env.devtools.refExecute.otherOpts \" " + extraJvmOptions + " \"" + ";\n";	
 		}
 	
-	}
-
-	public void jck9ConfigurationForMultijvmWithNoAgent(StfCoreExtension test) throws Exception {
-		String pathToJava = test.createJavaProcessDefinition().getCommand();
-		String pathToRmic = testJdk + File.separator + "bin" + File.separator + "rmic";
-		String pathToLib = testJdk + File.separator + "lib";
-		String pathToJavac = testJdk + File.separator + "bin" + File.separator + "javac";
-		DirectoryRef jckRuntimeNativeLibValue = nativesLoc;
-		DirectoryRef jckRuntimeJmxLibValue = nativesLoc;
-		String concurrency = "";
-		String keyword = "";
-		String libPath = "";
-		String testPlatform = "";
-		String robotAvailable = "";
-		String hostname = "";
-		String ipAddress = "";
-		extraJvmOptions = "";
-		
-		extraJvmOptions += " " + test.getJavaArgs(test.env().primaryJvm()) + " ";
-		
-		InetAddress addr = InetAddress.getLocalHost();
-		ipAddress = addr.getHostAddress();  
-		hostname = addr.getHostName();
-
-		freePort = getFreePort();
-		
-		if (freePort == -1) {
-			throw new StfException("Unable to get a free port");
-		}
-		
-		// Runtime settings
-		if (testSuite == TestSuite.RUNTIME) {
-			keyword = "keywords !interactive";
-			
-			if (platform.equals("win32")) {
-				testPlatform = "Windows";
-				libPath = "PATH";
-				robotAvailable = "Yes";
-				concurrency = "1";
-				fileContent += "set jck.env.testPlatform.systemRoot " + System.getenv("WINDIR") + ";\n";
-			} else if (platform.equals("linux") || platform.equals("mac")) {
-				testPlatform = "Linux";
-				libPath = "LD_LIBRARY_PATH";
-				robotAvailable = "Yes";
-				concurrency = "1";
-			} else if (platform.equals("aix")) {
-				testPlatform = "Linux";
-				libPath = "LIBPATH";
-				robotAvailable = "Yes";
-				concurrency = "1";
-			} else if (platform.equals("zos")) {
-				//pathToLib = testJdk + File.separator + "lib";
-				testPlatform = "Linux";
-				libPath = "LIBPATH";
-				robotAvailable = "No";
-				concurrency = "4";
-				if ( testsRequireDisplay(tests) ) {
-					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
-					fileContent += "set jck.env.runtime.testExecute.otherEnvVars LIBPATH=/usr/lpp/tcpip/X11R66/lib" + ";\n";
-				}
-			} else {
-					throw new StfException("Unknown platform:: " + platform);
-			}
-			
-			if ( tests.contains("api/java_awt") || tests.contains("api/javax_swing") ) {
-				keyword += "&!robot";
-			}
-			
-			fileContent += "concurrency " + concurrency + ";\n";
-			fileContent += "timeoutfactor 1" + ";\n";				// java_awt and javax_management require more than 1h to finish tests
-			fileContent += keyword + ";\n";
-			fileContent += "set jck.env.testPlatform.os " + testPlatform + ";\n";
-			fileContent += "set jck.env.runtime.testExecute.cmdAsString \"" + pathToJava + "\"" + ";\n";
-			
-			if ( tests.contains("api/java_awt") || tests.contains("api/javax_swing") ) {
-				fileContent += "set jck.env.runtime.awt.robotAvailable " + robotAvailable + ";\n";
-			}
-			
-			if ( tests.equals("api/java_lang") || tests.contains("api/java_lang/instrument") ||
-				tests.contains("api/javax_management") || tests.startsWith("vm") ) {
-				fileContent += "set jck.env.runtime.testExecute.libPathEnv " + libPath + ";\n";
-				fileContent += "set jck.env.runtime.testExecute.nativeLibPathValue \"" + jckRuntimeNativeLibValue + "\"" + ";\n";
-			}
-			if ( tests.contains("api/javax_management") ) {
-				fileContent += "set jck.env.runtime.testExecute.jmxResourcePathValue \"" + jckRuntimeJmxLibValue + "\"" + ";\n";
-			}
-			if ( tests.contains("api/javax_sound") ) {
-				fileContent += "set jck.env.runtime.audio.canPlaySound No" + ";\n";
-				fileContent += "set jck.env.runtime.audio.canPlayMidi No" + ";\n";
-				fileContent += "set jck.env.runtime.audio.canRecordSound No" + ";\n";
-			}
-			if ( tests.contains("api/org_ietf") || tests.contains("api/javax_security") ) {
-				readKrbConfFile();
-				if (KerberosConfig.kdcHostName == null || KerberosConfig.kdcRealmName == null){
-					throw new StfException(tests + "expects kdcHostname and kdcRealmname. Recheck if the values are proper in the supplied kdc conf file.");
-				}
-				
-				fileContent += "set jck.env.runtime.jgss.krb5ClientPassword passw0rd" + ";\n";
-				fileContent += "set jck.env.runtime.jgss.krb5ClientUsername svtclient1/" + KerberosConfig.kdcHostName+'@'+KerberosConfig.kdcRealmName + ";\n";
-				fileContent += "set jck.env.runtime.jgss.krb5ServerPassword passw0rd" + ";\n";
-				fileContent += "set jck.env.runtime.jgss.krb5ServerUsername svtserver1/" + KerberosConfig.kdcHostName+'@'+KerberosConfig.kdcRealmName + ";\n";
-				fileContent += "set jck.env.runtime.jgss.kdcHostName " + KerberosConfig.kdcHostName + ";\n";
-				fileContent += "set jck.env.runtime.jgss.kdcRealmName " + KerberosConfig.kdcRealmName + ";\n";
-				
-				extraJvmOptions += "-Djava.security.krb5.conf=" + krbConfFile + " -DKRB5CCNAME=" + test.env().getResultsDir().toString() + File.separator + "krb5.cache" + " -DKRB5_KTNAME=" + test.env().getResultsDir().toString() + File.separator + "krb5.keytab";
-			}	
-			if ( tests.contains("api/java_net") ) {
-				fileContent += "set jck.env.runtime.net.testHost1Name " + testHost1Name + ";\n";
-				fileContent += "set jck.env.runtime.net.testHost1IPAddr " + testHost1Ip + ";\n";
-				fileContent += "set jck.env.runtime.net.testHost2Name " + testHost2Name + ";\n";
-				fileContent += "set jck.env.runtime.net.testHost2IPAddr " + testHost2Ip + ";\n";
-				fileContent += "set jck.env.runtime.url.httpURL " + httpUrl + ";\n";
-				fileContent += "set jck.env.runtime.url.ftpURL " + ftpUrl + ";\n";
-				fileContent += "set jck.env.runtime.url.fileURL " + fileUrl + ";\n";
-				fileContent += "set jck.env.runtime.net.localHostName " + hostname + ";\n";
-				fileContent += "set jck.env.runtime.net.localHostIPAddr " + ipAddress + ";\n";
-			}
-			if ( tests.contains("api/java_net") || tests.contains("api/org_omg") || tests.contains("api/javax_management") || tests.contains("api/javax_xml") || tests.contains("vm/jdwp")) {
-				fileContent += "set jck.env.runtime.remoteAgent.passiveHost localhost" + ";\n";
-				fileContent += "set jck.env.runtime.remoteAgent.passivePortDefault Yes" + ";\n";
-			}
-			if ( tests.contains("api/org_omg") ) {
-				fileContent += "set jck.env.runtime.idl.orbHost " + hostname + ";\n";
-			}	
-			if ( tests.contains("api/java_text") || tests.contains("api/java_util")) {
-				extraJvmOptions += " -Djava.ext.dirs=" + jckBase + File.separator + "lib" + File.separator + "extensions" + File.pathSeparator + 
-										testJdk + File.separator + "jre" + File.separator + "lib" + File.separator + "ext";
-			}
-			if (tests.contains("api/signaturetest")) {
-				fileContent += "set jck.env.runtime.staticsigtest.staticSigTestClasspathRemote \"" + getSignatureTestJars(pathToLib) + "\"" + ";\n";
-			}
-	
-			if (extraJvmOptions.contains("nofallback") && tests.startsWith("vm") ) {
-				fileContent += "set jck.env.testPlatform.typecheckerSpecific No" + ";\n";		
-			}
-
-			if ( tests.contains("api/org_ietf") || tests.contains("api/javax_security") ) {
-				readKrbConfFile();
-				if (KerberosConfig.kdcHostName == null || KerberosConfig.kdcRealmName == null){
-					throw new StfException(tests + "expects kdcHostname and kdcRealmname. Recheck if the values are proper in the supplied kdc conf file.");
-				}
-				
-				fileContent += "set jck.env.runtime.jgss.krb5ClientPassword passw0rd" + ";\n";
-				fileContent += "set jck.env.runtime.jgss.krb5ClientUsername svtclient1/" + KerberosConfig.kdcHostName+'@'+KerberosConfig.kdcRealmName + ";\n";
-				fileContent += "set jck.env.runtime.jgss.krb5ServerPassword passw0rd" + ";\n";
-				fileContent += "set jck.env.runtime.jgss.krb5ServerUsername svtserver1/" + KerberosConfig.kdcHostName+'@'+KerberosConfig.kdcRealmName + ";\n";
-				fileContent += "set jck.env.runtime.jgss.kdcHostName " + KerberosConfig.kdcHostName + ";\n";
-				fileContent += "set jck.env.runtime.jgss.kdcRealmName " + KerberosConfig.kdcRealmName + ";\n";
-				
-				extraJvmOptions += "-Djava.security.krb5.conf=" + krbConfFile + " -DKRB5CCNAME=" + test.env().getResultsDir().toString() + File.separator + "krb5.cache" + " -DKRB5_KTNAME=" + test.env().getResultsDir().toString() + File.separator + "krb5.keytab";
-			}	
-
-			// Let's append any extra jvm options provided to the script
-			fileContent += "set jck.env.runtime.testExecute.otherOpts \" " + extraJvmOptions + " \"" + ";\n";
-		}
-		
-		// Compiler settings
-		if (testSuite == TestSuite.COMPILER) {
-			
-			keyword = "keywords compiler";
-			
-			if (platform.equals("win32")) {
-				pathToRmic += ".exe";
-				testPlatform = "Windows";
-				concurrency = "1";
-			} else if (platform.equals("linux") || platform.equals("aix") || platform.equals("mac")) {
-			    testPlatform = "Linux";
-				concurrency = "1";	
-			} else if (platform.equals("zos")) {
-				pathToLib = testJdk + File.separator + "lib";
-				testPlatform = "Linux";
-				concurrency = "4";
-			} else {
-			    throw new StfException("Unknown platform:: " + platform);
-			}
-			
-			fileContent += "concurrency " + concurrency + ";\n";
-			fileContent += "timeoutfactor 1" + ";\n";							// lang.CLSS,CONV,STMT,INFR requires more than 1h to complete. lang.Annot,EXPR,LMBD require more than 2h to complete tests
-			fileContent += keyword + ";\n";
-			fileContent += "set jck.env.testPlatform.os " + testPlatform + ";\n";
-			fileContent += "set jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsString \"" + pathToJava + "\"" + ";\n";
-			
-			if (tests.contains("api/java_rmi")) {
-				fileContent += "set jck.env.compiler.testRmic.cmdAsString \"" + pathToRmic + "\"" + ";\n";
-			}
-			
-			if (tests.contains("api/signaturetest")) {
-				fileContent += "set jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspathRemote \"" + getSignatureTestJars(pathToLib) + "\"" + ";\n";
-			}
-			
-			fileContent += "set jck.env.compiler.compRefExecute.cmdAsString \"" + pathToJava + "\"" + ";\n";
-			fileContent += "set jck.env.compiler.testCompile.otherOpts \"-source 1.9 \"" + ";\n";
-			// Let's append any extra jvm options provided to the script
-			fileContent += "set jck.env.compiler.compRefExecute.otherOpts \" " + extraJvmOptions + " \"" + ";\n";	
-		}
-		// Devtools settings
-		if (testSuite == TestSuite.DEVTOOLS) {
-		
-			String xjcCmd = "";				// Required for all devtools test, except "java2schema" & "jaxws"
-			String jxcCmd = "";				// Required for "java2schema" test
-			String genCmd,impCmd  = "";		// Required for "jaxws" test
-		
-			if (platform.equals("win32")) {
-				pathToJava += ".exe";
-				pathToJavac += ".exe";
-				testPlatform = "Windows";
-				concurrency = "1";
-				xjcCmd = jckBase + File.separator + "win32" + File.separator + "bin" + File.separator + "xjc.bat";
-				jxcCmd = jckBase + File.separator + "win32" + File.separator + "bin" + File.separator + "schemagen.bat";
-				genCmd = jckBase + File.separator + "win32" + File.separator + "bin" + File.separator + "wsgen.bat";
-				impCmd = jckBase + File.separator + "win32" + File.separator + "bin" + File.separator + "wsimport.bat";
-			} else if (platform.equals("linux") || platform.equals("aix") || platform.equals("mac")) {
-				testPlatform = "Linux";
-				concurrency = "1";
-				xjcCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "xjc.sh";
-				jxcCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "schemagen.sh";
-				genCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "wsgen.sh";
-				impCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "wsimport.sh";
-			} else if (platform.equals("zos")) {
-				pathToJavac = testJdk + File.separator + "bin" + File.separator + "javac";
-				testPlatform = "Linux";
-				concurrency = "4";
-				xjcCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "xjc.sh";
-				jxcCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "schemagen.sh";
-				genCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "wsgen.sh";
-				impCmd = jckBase + File.separator + "linux" + File.separator + "bin" + File.separator + "wsimport.sh";
-			} else {
-				throw new StfException("Unknown platform:: " + platform);
-			}
-			
-			fileContent += "concurrency " + concurrency + ";\n";
-			fileContent += "timeoutfactor 1" + ";\n";							// All Devtools tests take less than 1h to finish.
-			
-			fileContent += "set jck.env.testPlatform.os " + testPlatform + ";\n";
-			fileContent += "set jck.env.devtools.testExecute.cmdAsString \"" + pathToJava + "\"" + ";\n";
-			fileContent += "set jck.env.devtools.refExecute.cmdAsFile \"" + pathToJava + "\"" + ";\n";
-			
-			fileContent += "set jck.env.devtools.scriptEnvVars \"" + "JAVA_HOME=\"" + testJdk + "\" TOOLS_HOME=\"" + testJdk + "\"" + "\"" + ";\n";
-			
-			if (tests.contains("java2schema")) {
-				fileContent += "set jck.env.devtools.jaxb.jxcCmd \"" + jxcCmd + "\"" + ";\n";
-			} else if (tests.contains("jaxws")) {
-				fileContent += "set jck.env.devtools.jaxws.cmdJavac \"" + pathToJavac + "\"" + ";\n";
-				fileContent += "set jck.env.devtools.jaxws.genCmd \"" + genCmd + "\"" + ";\n";
-				fileContent += "set jck.env.devtools.jaxws.impCmd \"" + impCmd + "\"" + ";\n";
-			} else {
-				fileContent += "set jck.env.devtools.jaxb.xjcCmd \"" + xjcCmd + "\"" + ";\n";
-			}
-			
-			// Let's append any extra jvm options provided to the script
-			fileContent += "set jck.env.devtools.refExecute.otherOpts \" " + extraJvmOptions + " \"" + ";\n";	
-		}
 	}
 	
 	private boolean testsRequireDisplay (String tests) {
@@ -1003,26 +758,57 @@ public class Jck implements StfPluginInterface {
 		// --add-modules options are required to make some modules visible on Java 9
 		if (jckVersion.contains("jck9") ) {
 			if (tests.contains("api/javax_activation")) {
-				testSpecificJvmOptions = "--add-modules java.activation";
+				testSpecificJvmOptions = " --add-modules java.activation";
 			}
-			if (tests.contains("api/javax_activity") || tests.contains("api/javax_rmi") || tests.contains("api/org_omg")) {
-				testSpecificJvmOptions = "--add-modules java.corba";
+			if (tests.contains("api/javax_activity")) {
+				testSpecificJvmOptions = " --add-modules java.corba";
 			}
-			if (tests.contains("api/javax_annotation") || tests.contains("api/java_lang")) {
+			if (tests.contains("api/javax_rmi")) {
+				testSpecificJvmOptions = " --add-modules java.corba";
+			}
+			if (tests.contains("api/org_omg")) {
+				testSpecificJvmOptions = " --add-modules java.corba";
+			}
+			if (tests.contains("api/javax_annotation")) {
 				testSpecificJvmOptions = "--add-modules java.xml.ws.annotation";
 			}
+			if (tests.contains("api/java_lang")) {
+				testSpecificJvmOptions = "--add-modules java.xml.ws.annotation,java.xml.bind,java.xml.ws,java.activation,java.corba";
+			}
 			if (tests.contains("api/javax_crypto") ) {
-				testSpecificJvmOptions = "--add-modules java.xml.crypto";
+				testSpecificJvmOptions = " --add-modules java.xml.crypto";
 			}
 			if (tests.contains("api/javax_sql") ) {
-				testSpecificJvmOptions = "--add-modules java.sql";
+				testSpecificJvmOptions = " --add-modules java.sql";
 			}
 			if (tests.contains("api/javax_transaction") ) {
-				testSpecificJvmOptions = "--add-modules java.transaction";
+				testSpecificJvmOptions = " --add-modules java.transaction";
 			}
 			if (tests.contains("api/javax_xml") ) {
-				testSpecificJvmOptions = "--add-modules java.xml";
+				testSpecificJvmOptions = " --add-modules java.xml.bind,java.xml.ws";
 			}
+			if (tests.contains("api/modulegraph")) {
+				testSpecificJvmOptions = "--add-modules java.activation,,java.corba,java.transaction,java.se.ee,java.xml.bind,java.xml.ws,java.xml.ws.annotation";
+			}
+			if (tests.contains("api/signaturetest")) {
+				testSpecificJvmOptions = "--add-modules java.activation,,java.corba,java.transaction,java.xml.bind,java.xml.ws,java.xml.ws.annotation";
+			}
+			if (tests.contains("java2schema") ) {
+				testSpecificJvmOptions = " --add-modules java.xml.bind";
+			}
+			if (tests.contains("xml_schema") ) {
+				testSpecificJvmOptions = " --add-modules java.xml.bind";
+			}
+			if (tests.contains("jaxws") ) {
+				testSpecificJvmOptions = " --add-modules java.xml.bind,java.xml.ws";
+			}
+			if (tests.contains("schema2java") ) {
+				testSpecificJvmOptions = " --add-modules java.xml.bind";
+			}
+			if (tests.contains("schema_bind") ) {
+				testSpecificJvmOptions = " --add-modules java.xml.bind";
+			}
+			//testSpecificJvmOptions = " --add-modules java.activation,java.corba,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.prefs,java.rmi,java.scripting,java.se,java.se.ee,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction,java.xml,java.xml.bind,java.xml.crypto,java.xml.ws,java.xml.ws.annotation";
 		}
 		return testSpecificJvmOptions;
 	}


### PR DESCRIPTION
Tests are running OK on VB Ubuntu and Windows 7.
There may be follow on changes as additional platforms are tested or if test suite changes.
