### PR TITLE
Fix for Malformed \uxxxx encoding error during make configure

### DIFF
--- a/openjdk.build/include/top.xml
+++ b/openjdk.build/include/top.xml
@@ -444,7 +444,11 @@ limitations under the License.
 				<arg value="-XshowSettings:properties"/>
 				<arg value="-version"/>
 			</exec>
-			<loadproperties srcFile="${properties_file}" prefix="@{java.id}." prefixValues="false"/>
+			<loadproperties srcFile="${properties_file}" prefix="@{java.id}." prefixValues="false">
+				<filterchain>
+					<replacestring from="\" to="\\" />
+				</filterchain>
+			</loadproperties>
 			<echoproperties>
 				<propertyset>
 					<propertyref prefix="@{java.id}."/>


### PR DESCRIPTION
Running build configure throws a malformed encoding exception
if there is "\u" character appearing in the PATH on Windows.
This fix resolves the issue by changing the single "\" to "\\"
in the generated file.

Fixes: #23

Signed-off-by: sabkrish <sabkrish@in.ibm.com>