### PR TITLE
 Allow users to pass arguments to the stf perl layer

### DIFF
--- a/openjdk.build/makefile
+++ b/openjdk.build/makefile
@@ -381,7 +381,7 @@ ifneq (,$(RESULTS_ROOT))
 	RESULTS_ROOT_ARG:=-results-root="$(RESULTS_ROOT)"
 endif
 
-STF_COMMAND:=perl $(STF_ROOT)$(D)stf.core$(D)scripts$(D)stf.pl $(JAVA_ARGS_ARG) -test-root="$(STF_ROOT);$(OPENJDK_SYSTEMTEST_TARGET_ROOT)" -systemtest-prereqs="$(RESOLVED_PREREQS_ROOT)" $(REPEAT_ARG_ARG) $(RESULTS_ROOT_ARG)
+STF_COMMAND:=perl $(STF_ROOT)$(D)stf.core$(D)scripts$(D)stf.pl $(JAVA_ARGS_ARG) -test-root="$(STF_ROOT);$(OPENJDK_SYSTEMTEST_TARGET_ROOT)" -systemtest-prereqs="$(RESOLVED_PREREQS_ROOT)" $(REPEAT_ARG_ARG) $(RESULTS_ROOT_ARG) $(STF_ARGS)
 
 # Macros to allow the tests to run to completion with a log of what passed and failed.
 # To turn on run 

--- a/openjdk.build/makefile
+++ b/openjdk.build/makefile
@@ -372,6 +372,10 @@ ifneq (,$(JAVA_ARGS))
   endif
 endif
 
+ifeq ($(RM_PASS),1)
+    RM_PASS_ARG:=-rm-pass
+endif
+
 ifneq (,$(REPEAT_ARG))
 	REPEAT_ARG_ARG:=-repeat=$(REPEAT_ARG)
 endif
@@ -381,7 +385,7 @@ ifneq (,$(RESULTS_ROOT))
 	RESULTS_ROOT_ARG:=-results-root="$(RESULTS_ROOT)"
 endif
 
-STF_COMMAND:=perl $(STF_ROOT)$(D)stf.core$(D)scripts$(D)stf.pl $(JAVA_ARGS_ARG) -test-root="$(STF_ROOT);$(OPENJDK_SYSTEMTEST_TARGET_ROOT)" -systemtest-prereqs="$(RESOLVED_PREREQS_ROOT)" $(REPEAT_ARG_ARG) $(RESULTS_ROOT_ARG) $(STF_ARGS)
+STF_COMMAND:=perl $(STF_ROOT)$(D)stf.core$(D)scripts$(D)stf.pl $(JAVA_ARGS_ARG) -test-root="$(STF_ROOT);$(OPENJDK_SYSTEMTEST_TARGET_ROOT)" -systemtest-prereqs="$(RESOLVED_PREREQS_ROOT)" $(REPEAT_ARG_ARG) $(RESULTS_ROOT_ARG) $(RM_PASS_ARG)
 
 # Macros to allow the tests to run to completion with a log of what passed and failed.
 # To turn on run 


### PR DESCRIPTION
If the user wants to use stf.pl options that we don't anticipate in
the makefile, this option allows them to do that. This prevents code
duplication and dependencies between the make and perl code.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>