### PR TITLE
Add ExcludeListType to jck9/runtime.jti to sync with others

### DIFF
--- a/openjdk.test.jck/config/jck9/runtime.jti
+++ b/openjdk.test.jck/config/jck9/runtime.jti
@@ -164,6 +164,7 @@ jck.env.testPlatform.typecheckerSpecific=Yes
 jck.env.testPlatform.useAgent=No
 # jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
 jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
 jck.excludeList.latestAutoCheck=No
 jck.excludeList.latestAutoCheckInterval=7
 jck.excludeList.latestAutoCheckMode=everyXDays


### PR DESCRIPTION
This directive is already in the corresponding jti file for JCK8b and also in the other jti files for JCK9. For unknown reasons it's causing an error on my systems, but not on @lumpfish 's VM. It seems logical to have it synchronised with the others, therefore I'm adding it as it removes an issue and allows the suites to run.