### PR TITLE
Fix osx support for JCK runs

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -486,7 +486,7 @@ public class Jck implements StfPluginInterface {
 				libPath = "PATH";
 				robotAvailable = "Yes";
 				concurrency = "1";
-			} else if (platform.equals("linux") || platform.equals("mac")) {
+			} else if (platform.equals("linux"))  {
 				libPath = "LD_LIBRARY_PATH";
 				robotAvailable = "Yes";
 				concurrency = "1";
@@ -499,6 +499,10 @@ public class Jck implements StfPluginInterface {
 				libPath = "LIBPATH";
 				robotAvailable = "No";
 				concurrency = "4";
+			} else if (platform.equals("macosx")) {
+				libPath = "DYLD_LIBRARY_PATH";
+				robotAvailable = "Yes";
+				concurrency = "1";
 			} else {
 				throw new StfException("Unknown platform:: " + platform);
 			}


### PR DESCRIPTION
Jck.java requires getOsgiOperatingSystemName() to return something useful. On macos it doesn't. This fix (along with an equivalent one to fix that method in the stf repository) will resolve this.

Fixes https://github.com/AdoptOpenJDK/stf/issues/20