### PR TITLE
Detect aarch64 in the arch string as arm

### DIFF
--- a/openjdk.build/include/top.xml
+++ b/openjdk.build/include/top.xml
@@ -541,7 +541,7 @@ limitations under the License.
 			</condition>
 			<condition property="@{property}" value="arm">
 				<and>
-					<contains string="@{arch}" substring="arm"/>
+					<contains string="@{arch}" substring="aarch64"/>
 				</and>
 			</condition>
 			<condition property="@{property}" value="ia">


### PR DESCRIPTION
This may not be a great idea and may not be complete, but should work as an initial tactical fix for running the JCK