### PR TITLE
Fix test validation value for double(1)

### DIFF
--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/math/MathAPITest.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/math/MathAPITest.java
@@ -2327,7 +2327,7 @@ public class MathAPITest extends TestCase
 			// We may not depend on the Oracle result as it may also contain the 1 ulp error tolerance. 
 			// For exact value, the user is expected to use ExactMath as opposed to Math.
 			assertTrue("toRadians(double)[0] ::", (double)-1.5687832071922932E304 == Math.toRadians((-Double.MAX_VALUE / 200)) || (double)-1.5687832071922935E304 == Math.toRadians((-Double.MAX_VALUE / 200)));
-			assertTrue("toRadians(double)[1] ::", (double)-6.275132828769172E303 == Math.toRadians((-Double.MAX_VALUE / 200)) || (double)-6.275132828769174E303 == Math.toRadians((-Double.MAX_VALUE / 200)));
+			assertTrue("toRadians(double)[1] ::", (double)-6.275132828769172E303 == Math.toRadians((-Double.MAX_VALUE / 500)) || (double)-6.275132828769174E303 == Math.toRadians((-Double.MAX_VALUE / 500)));
 			
 			assertEquals("toRadians(double)[2] ::", (double)6.275132828769172E303, Math.toRadians((Double.MAX_VALUE / 500)));
 			assertEquals("toRadians(double)[3] ::", (double)1.5687832071922932E304, Math.toRadians((Double.MAX_VALUE / 200)));


### PR DESCRIPTION
We need to update the validation value for double(1) test from 200 to 500, as the value originally was 500.
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>