### PR TITLE
Update makefile to tolerate both jck8b and jck10 header file locations

### DIFF
--- a/openjdk.test.jck/config/jck10/compiler.jti
+++ b/openjdk.test.jck/config/jck10/compiler.jti
@@ -1,0 +1,95 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK9 compiler template jti for STF automation
+INTERVIEW=com.sun.jck.interview.JCKParameters
+NAME=jck_compiler
+# TESTSUITE example: /jck/jck9/JCK-compiler-9
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-compiler-9
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.compiler.agent.networkClassLoading=No
+jck.env.compiler.agent.passivePort=
+jck.env.compiler.agent.resourcesRemoving=No
+# jck.env.compiler.compRefExecute.cmdAsFile example: /home/user/jdk9/bin/java
+jck.env.compiler.compRefExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.compRefExecute.otherEnvVars=
+jck.env.compiler.compRefExecute.otherOpts=
+jck.env.compiler.rmi.tcpLower=
+jck.env.compiler.rmi.tcpRange=No
+jck.env.compiler.rmi.tcpUpper=
+jck.env.compiler.rmic=Yes
+jck.env.compiler.services.autostartServices=
+jck.env.compiler.services.servicesOn=No
+jck.env.compiler.testCompile.annoProc=-processor \#
+jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
+jck.env.compiler.testCompile.classpath=command line option
+jck.env.compiler.testCompile.classpathOpt=-classpath \#
+# jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk9/bin/javac
+jck.env.compiler.testCompile.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk9/bin/javac
+jck.env.compiler.testCompile.compilerType=Java compiler API (JSR 199)
+jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.moduleOptions=Yes
+jck.env.compiler.testCompile.otherEnvVars=
+jck.env.compiler.testCompile.otherOpts=
+jck.env.compiler.testCompile.outDirOpt=-d \#
+jck.env.compiler.testCompile.outSrcDirOpt=-s \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=command line option
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
+# jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile example: /home/user/jdk9/bin/java
+jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
+jck.env.compiler.testRmic.classpath=command line option
+jck.env.compiler.testRmic.classpathOpt=-classpath \#
+# jck.env.compiler.testRmic.cmdAsFile example:  /home/user/jdk9/bin/rmic
+jck.env.compiler.testRmic.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testRmic.iiopOption=-iiop
+jck.env.compiler.testRmic.otherEnvVars=
+jck.env.compiler.testRmic.otherOpts=
+jck.env.compiler.testRmic.outDirOpt=-d \#
+jck.env.compiler.testRmic.v11Option=-v1.1
+jck.env.compiler.testRmic.v12Option=-v1.2
+jck.env.description=JCK9 compiler template jti for STF automation
+jck.env.envName=jck_compiler
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=--add-modules \#[,\#]\ncompilerModulePathOptionTemplate\=--module-path \#\ncompilerModuleSourcePathOptionTemplate\=--module-source-path \#\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=\nvmModulePathOptionTemplate\=\nvmAddModsOptionTemplate\=\n
+jck.env.platform=jre
+jck.env.platformModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
+jck.env.product=compiler
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: :1 or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+jck.env.testPlatform.systemRoot=C\:\\windows
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
+jck.keywords.needKeywords=Yes
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.chooseTests=Yes
+jck.tests.needTests=No
+jck.tests.setOfModules=
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck10/devtools.jti
+++ b/openjdk.test.jck/config/jck10/devtools.jti
@@ -1,0 +1,87 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK9 devtools template jti for STF automation
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_devtools
+# TESTSUITE example: /jck/jck9/JCK-devtools-9
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-devtools-9
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.description=devtools.jit for STF automation
+jck.env.devtools.agent.networkClassLoading=No
+jck.env.devtools.agent.passivePort=
+jck.env.devtools.agent.resourcesRemoving=No
+jck.env.devtools.jaxb.defaultOperationMode=Yes
+jck.env.devtools.jaxb.java2schema=Yes
+# jck.env.devtools.jaxb.jxcCmd example: /jck/jck9/JCK-devtools-9/linux/bin/schemagen
+jck.env.devtools.jaxb.jxcCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxb.needJaxbClasses=No
+jck.env.devtools.jaxb.skipJ2XOptional=Yes
+# jck.env.devtools.jaxb.xjcCmd=/jck/jck9/JCK-devtools-9/linux/bin/xjc
+jck.env.devtools.jaxb.xjcCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxb.xml_schema=Yes
+jck.env.devtools.jaxb=Yes
+# jck.env.devtools.jaxws.cmdJavac=/home/user/jdk/jdk9/bin/javac
+jck.env.devtools.jaxws.cmdJavac=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.jaxws.genCmd=/jck/jck9/JCK-devtools-9/linux/bin/wsgen
+jck.env.devtools.jaxws.genCmd=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.jaxws.impCmd=/jck/jck9/JCK-devtools-9/linux/bin/wsimport
+jck.env.devtools.jaxws.impCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxws=Yes
+# jck.env.devtools.refExecute.cmdAsFile=/home/user/jdk/jdk9/bin/java
+jck.env.devtools.refExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.refExecute.otherEnvVars=
+jck.env.devtools.refExecute.otherOpts=
+jck.env.devtools.scriptEnvVars=
+jck.env.devtools.services.autostartServices=
+jck.env.devtools.services.servicesOn=No
+jck.env.devtools.testExecute.additionalClasspath=
+jck.env.devtools.testExecute.classpath=command line option
+jck.env.devtools.testExecute.classpathEnv=CLASSPATH
+jck.env.devtools.testExecute.classpathOpt=-classpath \#
+# jck.env.devtools.testExecute.cmdAsFile=/home/user/jdk/jdk9/bin/java
+jck.env.devtools.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.testExecute.otherEnvVars=
+jck.env.devtools.testExecute.otherOpts=
+jck.env.envName=jck_devtools
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=\ncompilerModulePathOptionTemplate\=\ncompilerModuleSourcePathOptionTemplate\=\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=\nvmModulePathOptionTemplate\=\nvmAddModsOptionTemplate\=\n
+jck.env.platform=jre
+jck.env.platformModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
+jck.env.product=devtools
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyHost=
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
+jck.keywords.needKeywords=No
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.chooseTests=Yes
+jck.tests.needTests=No
+jck.tests.setOfModules=
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck10/runtime.jti
+++ b/openjdk.test.jck/config/jck10/runtime.jti
@@ -1,0 +1,185 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK9 runtime template jti for STF automation
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_runtime
+QUESTION=jck.end
+# TESTSUITE example: /jck/jck9/JCK-runtime-9
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-runtime-9
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.description=JCK9 runtime template jti for STF automation
+jck.env.envName=jck_runtime
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=\ncompilerModulePathOptionTemplate\=\ncompilerModuleSourcePathOptionTemplate\=\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=--module \#\nvmModulePathOptionTemplate\=--module-path \#\nvmAddModsOptionTemplate\=--add-modules \#[,\#]\n
+jck.env.platform=jre
+jck.env.platformModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
+jck.env.product=runtime
+jck.env.runtime.RemoteAgent=Yes
+jck.env.runtime.agent.networkClassLoading=No
+jck.env.runtime.agent.passivePort=
+jck.env.runtime.agent.resourcesRemoving=No
+jck.env.runtime.audio.canPlayMidi=Yes
+jck.env.runtime.audio.canPlaySound=Yes
+jck.env.runtime.audio.canRecordSound=Yes
+jck.env.runtime.audio.soundURLChoice=Yes
+jck.env.runtime.audio.soundURLYesJCK=.WAV
+jck.env.runtime.audio=Yes
+jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
+jck.env.runtime.awt.robotAvailable=Yes
+jck.env.runtime.awt.splashScreenOpt=-splash\:\#
+jck.env.runtime.awt.splashScreenSupported=Yes
+jck.env.runtime.awt=Yes
+jck.env.runtime.fp.doubleMaxExponent=
+jck.env.runtime.fp.doubleMinExponent=
+jck.env.runtime.fp.floatMaxExponent=
+jck.env.runtime.fp.floatMinExponent=
+jck.env.runtime.fp.format=Intel, 15 bit exponent
+jck.env.runtime.fp.supportExtended=Yes
+jck.env.runtime.fp=Yes
+jck.env.runtime.ftpSupport=Yes
+# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
+jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.idl.orbPort=9876
+jck.env.runtime.idl=Yes
+jck.env.runtime.jaas.authPolicy=standard system property
+jck.env.runtime.jaas.loginConfig=standard system property
+jck.env.runtime.jaas=Yes
+jck.env.runtime.jdwp.VMSuspended=Yes
+jck.env.runtime.jdwp.connectorType=attaching
+jck.env.runtime.jdwp.jdwpOpts=-agentlib\:jdwp\=server\=y,transport\=dt_socket,address\=localhost\:35000,suspend\=y
+jck.env.runtime.jdwp.jdwpSupported=Yes
+jck.env.runtime.jdwp.transportAddress=localhost\:35000
+jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
+jck.env.runtime.jdwp=Yes
+jck.env.runtime.jgss.kdc=No
+# jck.env.runtime.jgss.kdcHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.jgss.kdcHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jgss.kdcRealm=No
+# jck.env.runtime.jgss.kdcRealmName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.jgss.kdcRealmName=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ClientPassword example: password2
+jck.env.runtime.jgss.krb5ClientPassword=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ClientUsername example: user2
+jck.env.runtime.jgss.krb5ClientUsername=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ServerPassword example: password1
+jck.env.runtime.jgss.krb5ServerPassword=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ServerUsername example: user1
+jck.env.runtime.jgss.krb5ServerUsername=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jgss.loginModule=Yes
+jck.env.runtime.jgss=Yes
+jck.env.runtime.jplis.jplisCmdLine=Yes
+jck.env.runtime.jplis.jplisLivePhase=Yes
+jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
+jck.env.runtime.jplis=Yes
+jck.env.runtime.jsse.isJKSSupported=Yes
+jck.env.runtime.jsse=Yes
+jck.env.runtime.memory.expectOutOfMemory=Yes
+jck.env.runtime.memory.memoryAllocation=Yes
+jck.env.runtime.memory=Yes
+# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
+jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.other=Yes
+jck.env.runtime.net.tcpLower=
+jck.env.runtime.net.tcpRange=No
+jck.env.runtime.net.tcpUpper=
+# jck.env.runtime.net.testHost1IPAddr example: n.n.n.n
+jck.env.runtime.net.testHost1IPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost1Name example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.testHost1Name=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost2IPAddr example: n.n.n.n
+jck.env.runtime.net.testHost2IPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost2Name example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.testHost2Name=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.udpLower=
+jck.env.runtime.net.udpRange=No
+jck.env.runtime.net.udpUpper=
+jck.env.runtime.net=Yes
+jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.print=Yes
+jck.env.runtime.remoteAgent.loadClasses=No
+jck.env.runtime.remoteAgent.passiveHost=localhost
+jck.env.runtime.remoteAgent.passivePort=
+jck.env.runtime.remoteAgent.passivePortDefault=Yes
+jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
+jck.env.runtime.services.autostartServices=RMI_service ORB_service Distributed_Agent
+jck.env.runtime.services.servicesOn=No
+jck.env.runtime.testExecute.activationPortValue=
+jck.env.runtime.testExecute.additionalClasspath=
+jck.env.runtime.testExecute.classpath=command line option
+jck.env.runtime.testExecute.classpathEnv=CLASSPATH
+jck.env.runtime.testExecute.classpathOpt=-classpath \#
+# jck.env.runtime.testExecute.cmdAsFile example: /home/user/jdk9/jre/bin/java
+jck.env.runtime.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.jarExecution=Yes
+jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
+jck.env.runtime.testExecute.jmx=Yes
+# jck.env.runtime.testExecute.jmxResourcePathFileValue example: /jck/jck9/natives/linux_x86-64
+jck.env.runtime.testExecute.jmxResourcePathFileValue=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.jni=Yes
+jck.env.runtime.testExecute.jvmti=Yes
+jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
+jck.env.runtime.testExecute.jvmtiLivePhase=Yes
+jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
+jck.env.runtime.testExecute.libPath=environment variable
+# jck.env.runtime.testExecute.libPathEnv example: LD_LIBRARY_PATH
+jck.env.runtime.testExecute.libPathEnv=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.moduleOptions=Yes
+# jck.env.runtime.testExecute.nativeLibPathFileValue example: /jck/jck9/natives/linux_x86-64
+jck.env.runtime.testExecute.nativeLibPathFileValue=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
+jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
+jck.env.runtime.testExecute.optionSpecification=Yes
+jck.env.runtime.testExecute.otherEnvVars=
+jck.env.runtime.testExecute.otherOpts=
+jck.env.runtime.testExecute.rmi=Yes
+jck.env.runtime.testExecute.rmiActivationSupport=Yes
+jck.env.runtime.testExecute.stdActivationPort=Yes
+jck.env.runtime.testExecute.verify=-Xfuture
+# jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
+jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
+jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.url=Yes
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+# jck.env.testPlatform.systemRoot example: C\:\\WINDOWS
+jck.env.testPlatform.systemRoot=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck9/excludes/jck9.jtx\n/jck/jck9/excludes/jck9.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
+jck.keywords.needKeywords=Yes
+jck.knownFailuresList.customFiles=
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.chooseTests=Yes
+jck.tests.needTests=No
+jck.tests.setOfModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -77,76 +77,76 @@ export AND_IF_SUCCESSFUL
 
 VPATH=$(SRCDIR)/src/share/lib/jni/:$(SRCDIR)/src/share/lib/atr/:$(SRCDIR)/src/share/lib/jvmti/:$(SRCDIR)/tests/api/javax_management/loading/data/archives/src/C/
 
-#Following are platform and compiler specific settingss
+#Following are platform and compiler specific settings
 ifeq ($(PLATFORM),linux_x86-32)
 	CC=gcc
-	CFLAGS=-fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared 
 endif	
 
 ifeq ($(PLATFORM),linux_ppc-32)
 	CC=gcc
-	CFLAGS=-fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared 
 endif	
 
 ifeq ($(PLATFORM),linux_ppc-64)
 	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared
 endif
 
 ifeq ($(PLATFORM),linux_ppcle-64)
 	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared
 endif
 
 ifeq ($(PLATFORM),linux_x86-64)
 	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared
 endif
 
 ifeq ($(PLATFORM),osx_x86-64)
 	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/amd64
+	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/amd64 
 	LDFLAGS=-shared
 endif
 
 ifeq ($(PLATFORM),aix_ppc-32)
 	CC=xlc
-	CFLAGS=-qstaticinline -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-qstaticinline -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-G
 endif
 
 ifeq ($(PLATFORM),aix_ppc-64)
 	CC=xlc
-	CFLAGS=-q64 -qstaticinline -D_LP64 -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-q64 -qstaticinline -D_LP64 -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-G 
 endif
 
 ifeq ($(PLATFORM),linux_390-31)
 	CC=gcc
-	CFLAGS=-m31 -fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-m31 -fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared
 endif
 
 ifeq ($(PLATFORM),linux_390-64)
 	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared
 endif
 
 ifeq ($(PLATFORM),linux_arm-32)
 	CC=gcc
-	CFLAGS=-fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared
 endif
 
 ifeq ($(PLATFORM),linux_arm-64)
 	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-fPIC -D_LP64 -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
 	LDFLAGS=-shared
 endif
 
@@ -191,45 +191,45 @@ endif
 
 ifeq ($(PLATFORM),hp_ux-32)
         CC=cc
-        CFLAGS=+DD32 +z -c -I$(SRCDIR)/src/share/lib/jni/include/solaris
+        CFLAGS=+DD32 +z -c -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
         LDFLAGS=
 endif
 ifeq ($(PLATFORM),hp_ux-64)
         CC=cc
-        CFLAGS=+DD64 +z -c -I$(SRCDIR)/src/share/lib/jni/include/solaris
+        CFLAGS=+DD64 +z -c -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
         LDFLAGS=
 endif
 ifeq ($(PLATFORM),hp_ia-32)
         CC=cc
-        CFLAGS=+DD32 +z -c -I$(SRCDIR)/src/share/lib/jni/include/solaris
+        CFLAGS=+DD32 +z -c -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
         LDFLAGS=
 endif
 ifeq ($(PLATFORM),hp_ia-64)
         CC=cc
-        CFLAGS=+DD64 +z -c -I$(SRCDIR)/src/share/lib/jni/include/solaris
+        CFLAGS=+DD64 +z -c -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
         LDFLAGS=
 endif
 ifeq ($(PLATFORM),sol_sparc-32)
         CC=gcc
-        CFLAGS=-nodefaultlibs -fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris
+        CFLAGS=-nodefaultlibs -fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
         LDFLAGS=-shared
 endif
 ifeq ($(PLATFORM),sol_sparc-64)
         CC=gcc
-        CFLAGS= -m64 -nodefaultlibs -fPIC -R/usr/sfw/lib/64 -I$(SRCDIR)/src/share/lib/jni/include/solaris
+        CFLAGS= -m64 -nodefaultlibs -fPIC -R/usr/sfw/lib/64 -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
         LDFLAGS=-shared
 endif
 ifeq ($(PLATFORM),sol_x86-32)
         #CC=cc
         #CFLAGS=-G -KPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris
 	CC=gcc
-	CFLAGS=-G -fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris
+	CFLAGS=-G -fPIC -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
         LDFLAGS=
 endif
 ifeq ($(PLATFORM),sol_x86-64)
         #CC=gcc
 	CC=cc
-        CFLAGS=-m64 -fPIC -R/usr/sfw/lib/64  -I$(SRCDIR)/src/share/lib/jni/include/solaris
+        CFLAGS=-m64 -fPIC -R/usr/sfw/lib/64  -I$(SRCDIR)/src/share/lib/jni/include/solaris -I$(SRCDIR)/src/share/lib/jni/include/linux
         LDFLAGS=-shared
 endif
 


### PR DESCRIPTION
Oracle appear to have switched the "generic UNIX" header file directory name from solaris to linux. While we could get more creative than this, the simplest solution would appear to be to let the makefile search in both locations, so that's what I've implemented. Partially fixes https://github.com/AdoptOpenJDK/stf/issues/35