### PR TITLE
Tolerate alternative native include dir on Windows for JCK10

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -171,7 +171,7 @@ endif
 ifeq ($(PLATFORM),win_x86-32)
 	CC=cl
 	CFLAGS=/DWIN32 /D_WINDOWS 
-	LDFLAGS=/LD /MD -I$(SRCDIR)/src/share/lib/jni/include/win32
+	LDFLAGS=/LD /MD -I$(SRCDIR)/src/share/lib/jni/include/win32 -I$(SRCDIR)/src/share/lib/jni/include/windows
 	LIBPREF=
 	LIBEXT=dll
 	OFLAG=/Fe
@@ -183,7 +183,7 @@ endif
 ifeq ($(PLATFORM),win_x86-64)
 	CC=cl
 	CFLAGS=/DWIN32 /D_WINDOWS 
-	LDFLAGS=/LD /MD -I$(SRCDIR)/src/share/lib/jni/include/win32
+	LDFLAGS=/LD /MD -I$(SRCDIR)/src/share/lib/jni/include/win32 -I$(SRCDIR)/src/share/lib/jni/include/windows
 	LIBPREF=
 	LIBEXT=dll
 	OFLAG=/Fe


### PR DESCRIPTION
Similar to what we had to do to translate the default *IX native include dir from `solaris` to `linux` we need to allow both `win32` for earlier JCK versions and `windows` for JCK10