### PR TITLE
Remove ant-contrib depdendency from openjdk.modularity.test build file

### DIFF
--- a/openjdk.test.modularity/build.xml
+++ b/openjdk.test.modularity/build.xml
@@ -14,7 +14,6 @@ limitations under the License.
 -->
 
 <project name="adoptopenjdk.test.modularity" default="build">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<!-- Set default for source_root.  -->
 	<property name="source_root" location="../"/>
 	


### PR DESCRIPTION
Remove ant-contrib depdendency from openjdk.modularity.test build file
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>