### PR TITLE
Remove Java version number from native lib path for jlink test

### DIFF
--- a/openjdk.test.modularity/build.xml
+++ b/openjdk.test.modularity/build.xml
@@ -36,11 +36,10 @@ limitations under the License.
     <property name="src_dir" value="src" />
 	<property name="bin_dir" value="${source_root}/${module}/bin" /> 
 	
-	<property name="native-release" value="${JAVA_VERSION}"/>
 	<property name="jlink-testcase-src" value="${source_root}/${module}/${src_dir}/tests/com.test.jlink"/>
 	<property name="jlink-nativedir" value="${bin_dir}/tests/com.test.jlink/native"/>
-	<property name="jlink-outdir" value="${jlink-nativedir}/bin/${native-release}"/>
-	<property name="jlink-headerdir" value="${jlink-nativedir}/lib/${native-release}"/>
+	<property name="jlink-outdir" value="${jlink-nativedir}/bin"/>
+	<property name="jlink-headerdir" value="${jlink-nativedir}/lib"/>
 		
 	<!--List of JNI testcases-->
 	<property name="native_src" value= "JniTest"/>
@@ -321,7 +320,7 @@ limitations under the License.
 			</or>
 		</condition>
 		
-		<property name="headerdir" value="${jlink-nativedir}/lib/${native-release}"/>
+		<property name="headerdir" value="${jlink-nativedir}/lib"/>
 		<mkdir dir="${headerdir}" />
 		 
 		<!-- First delete the header files -->

--- a/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/JlinkPluginOptionsTest.java
+++ b/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/JlinkPluginOptionsTest.java
@@ -102,8 +102,7 @@ public class JlinkPluginOptionsTest implements StfPluginInterface {
       helloDir = test.env().findTestDirectory("openjdk.test.modularity/bin/common-mods/com.hello");
       jLinkDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink");
 	  DirectoryRef confDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/conf");
-	  DirectoryRef nativeDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/native/bin" +
-			  					"/SE" + test.env().primaryJvm().getJavaVersionCode() + "/" + test.env().getPlatform());
+	  DirectoryRef nativeDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/native/bin/" + test.env().getPlatform());
 	  
 	  /*Creating a modularized jar / jmod out of com.test.jlink.*/ 
 		 

--- a/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/JlinkTest.java
+++ b/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/JlinkTest.java
@@ -95,8 +95,7 @@ public class JlinkTest implements StfPluginInterface {
 		
 		DirectoryRef jLinkDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink");
 		DirectoryRef confDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/conf");
-		nativeDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/native/bin" + 
-																				"/SE" + test.env().primaryJvm().getJavaVersionCode() + "/" + test.env().getPlatform());
+		nativeDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/native/bin/" + test.env().getPlatform());
 		DirectoryRef helloDir = test.env().findTestDirectory("openjdk.test.modularity/bin/common-mods/com.hello");
 		
 		/*Creating a modularized jar / jmod out of com.test.jlink.*/ 


### PR DESCRIPTION
Remove Java version number from native lib path for jlink test 
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>