### PR TITLE
Add osx_x86-64 to list of supported platforms

### DIFF
--- a/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
+++ b/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
@@ -41,7 +41,7 @@ P=:
 ###
 # Check platform is set to a single valid value
 ###
-VALID_PLATFORMS?=aix_ppc-32,aix_ppc-64,linux_390-31,linux_390-64,linux_ppc-32,linux_ppc-64,linux_x86-32,linux_x86-64,win_x86-32,win_x86-64,zos_390-31,zos_390-64,linux_ppcle-64,linux_arm-32
+VALID_PLATFORMS?=osx_x86-64,aix_ppc-32,aix_ppc-64,linux_390-31,linux_390-64,linux_ppc-32,linux_ppc-64,linux_x86-32,linux_x86-64,win_x86-32,win_x86-64,zos_390-31,zos_390-64,linux_ppcle-64,linux_arm-32
 ifndef PLATFORM
   $(error "The variable PLATFORM needs to be defined")
 endif
@@ -87,6 +87,12 @@ endif
 ifeq ($(PLATFORM),linux_390-31)
     CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m31 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
     LFLAGS=-m31 -shared -o
+endif
+
+ifeq ($(PLATFORM),osx_x86-64)
+	CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m64 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
+	LFLAGS=-shared -m64 -o
+	IFLAGS=-I. -I$(HEADERDIR) -I$(JAVA_HOME)/include/darwin -I$(JAVA_HOME)/include -I/usr/include
 endif
 
 ifeq ($(PLATFORM),win_x86-32)


### PR DESCRIPTION
Add osx_x86-64 to list of supported platforms for modularity native tests
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>