### PR TITLE
Update <get-platform-arch> macro for ppc64le platform

### DIFF
--- a/openjdk.build/include/top.xml
+++ b/openjdk.build/include/top.xml
@@ -565,7 +565,7 @@ limitations under the License.
 			</condition>
 			<condition property="@{property}" value="ppcle">
 				<and>
-					<contains string="@{arch}" substring="ppcle"/>
+					<contains string="@{arch}" substring="ppc64le"/>
 				</and>
 			</condition>
 			<condition property="@{property}" value="ppc">


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9-systemtest/issues/29
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>