### PR TITLE
Remove hardcoded -Xmx2G

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -265,10 +265,8 @@ public class Jck implements StfPluginInterface {
 		// If we're testing a J9 VM that will result in dumps being taken and a non-zero return code
 		// which stf will detect as a failure. So in this case add the -Xdump options required to suppress
 		// taking dumps for OutOfMemory.
-		// -Xmx2G is added for OpenJ9 to trigger an expected OOM at api/java_awt/Image_pack/WritableRaster/index.html#CreatePackedRasterTest1
-		// Otherwise OpenJ9 has default larger heap size in certain scenarios, no OOM and fails the test.
 		if (test.env().primaryJvm().isIBMJvm()) {
-			suppressOutOfMemoryDumpOptions = " -Xmx2G -Xdump:system:none -Xdump:system:events=gpf+abort+traceassert+corruptcache -Xdump:snap:none -Xdump:snap:events=gpf+abort+traceassert+corruptcache -Xdump:java:none -Xdump:java:events=gpf+abort+traceassert+corruptcache -Xdump:heap:none -Xdump:heap:events=gpf+abort+traceassert+corruptcache";
+			suppressOutOfMemoryDumpOptions = " -Xdump:system:none -Xdump:system:events=gpf+abort+traceassert+corruptcache -Xdump:snap:none -Xdump:snap:events=gpf+abort+traceassert+corruptcache -Xdump:java:none -Xdump:java:events=gpf+abort+traceassert+corruptcache -Xdump:heap:none -Xdump:heap:events=gpf+abort+traceassert+corruptcache";
 		}
 	}
 	


### PR DESCRIPTION
Remove hard-coded `-Xmx2G`

Latest investigation shows the original `JCK` failure can be addressed without this hard-coded command line option;
This option also reserves the virtual address which might not be required, and causes `OOM` in certain scenarios.

Reviewer: @smlambert
FYI: @lumpfish @DanHeidinga

Signed-off-by: Jason Feng <fengj@ca.ibm.com>