### PR TITLE
Add arm to supported os.arch property values for arm32 platforms

### DIFF
--- a/openjdk.build/include/top.xml
+++ b/openjdk.build/include/top.xml
@@ -592,6 +592,11 @@ limitations under the License.
 					<contains string="@{arch}" substring="aarch64"/>
 				</and>
 			</condition>
+			<condition property="@{property}" value="arm">
+				<and>
+					<contains string="@{arch}" substring="arm"/>
+				</and>
+			</condition>
 			<condition property="@{property}" value="ia">
 				<and>
 					<contains string="@{arch}" substring="IA64"/>


### PR DESCRIPTION
Resolves https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/160
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>