### PR TITLE
Enable JCK11 test

### DIFF
--- a/openjdk.test.jck/config/jck11/compiler.jti
+++ b/openjdk.test.jck/config/jck11/compiler.jti
@@ -1,0 +1,95 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK11 compiler template jti for STF automation
+INTERVIEW=com.sun.jck.interview.JCKParameters
+NAME=jck_compiler
+# TESTSUITE example: /jck/jck11/JCK-compiler-10
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-compiler-10
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.compiler.agent.networkClassLoading=No
+jck.env.compiler.agent.passivePort=
+jck.env.compiler.agent.resourcesRemoving=No
+# jck.env.compiler.compRefExecute.cmdAsFile example: /home/user/jdk10/bin/java
+jck.env.compiler.compRefExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.compRefExecute.otherEnvVars=
+jck.env.compiler.compRefExecute.otherOpts=
+jck.env.compiler.rmi.tcpLower=
+jck.env.compiler.rmi.tcpRange=No
+jck.env.compiler.rmi.tcpUpper=
+jck.env.compiler.rmic=Yes
+jck.env.compiler.services.autostartServices=
+jck.env.compiler.services.servicesOn=No
+jck.env.compiler.testCompile.annoProc=-processor \#
+jck.env.compiler.testCompile.annoProcOpt=-A\#key\=\#value
+jck.env.compiler.testCompile.classpath=command line option
+jck.env.compiler.testCompile.classpathOpt=-classpath \#
+# jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk10/bin/javac
+jck.env.compiler.testCompile.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.cmdAsFile example: /home/user/jdk10/bin/javac
+jck.env.compiler.testCompile.compilerType=Java compiler API (JSR 199)
+jck.env.compiler.testCompile.defaultCompiler=Yes
+jck.env.compiler.testCompile.moduleOptions=Yes
+jck.env.compiler.testCompile.otherEnvVars=
+jck.env.compiler.testCompile.otherOpts=
+jck.env.compiler.testCompile.outDirOpt=-d \#
+jck.env.compiler.testCompile.outSrcDirOpt=-s \#
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpath=command line option
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathEnv=CLASSPATH
+jck.env.compiler.testCompile.testCompileAPImultiJVM.classpathOpt=-classpath \#
+# jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile example: /home/user/jdk10/bin/java
+jck.env.compiler.testCompile.testCompileAPImultiJVM.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherEnvVars=
+jck.env.compiler.testCompile.testCompileAPImultiJVM.otherOpts=
+jck.env.compiler.testRmic.classpath=command line option
+jck.env.compiler.testRmic.classpathOpt=-classpath \#
+# jck.env.compiler.testRmic.cmdAsFile example:  /home/user/jdk10/bin/rmic
+jck.env.compiler.testRmic.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.compiler.testRmic.iiopOption=-iiop
+jck.env.compiler.testRmic.otherEnvVars=
+jck.env.compiler.testRmic.otherOpts=
+jck.env.compiler.testRmic.outDirOpt=-d \#
+jck.env.compiler.testRmic.v11Option=-v1.1
+jck.env.compiler.testRmic.v12Option=-v1.2
+jck.env.description=JCK11 compiler template jti for STF automation
+jck.env.envName=jck_compiler
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=--add-modules \#[,\#]\ncompilerModulePathOptionTemplate\=--module-path \#\ncompilerModuleSourcePathOptionTemplate\=--module-source-path \#\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=\nvmModulePathOptionTemplate\=\nvmAddModsOptionTemplate\=\n
+jck.env.platform=jre
+jck.env.platformModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
+jck.env.product=compiler
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: :1 or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+jck.env.testPlatform.systemRoot=C\:\\windows
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck11/excludes/jck11.jtx\n/jck/jck11/excludes/jck11.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
+jck.keywords.needKeywords=Yes
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.chooseTests=Yes
+jck.tests.needTests=No
+jck.tests.setOfModules=
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck11/devtools.jti
+++ b/openjdk.test.jck/config/jck11/devtools.jti
@@ -1,0 +1,87 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK11 devtools template jti for STF automation
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_devtools
+# TESTSUITE example: /jck/jck11/JCK-devtools-10
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-devtools-10
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.description=devtools.jit for STF automation
+jck.env.devtools.agent.networkClassLoading=No
+jck.env.devtools.agent.passivePort=
+jck.env.devtools.agent.resourcesRemoving=No
+jck.env.devtools.jaxb.defaultOperationMode=Yes
+jck.env.devtools.jaxb.java2schema=Yes
+# jck.env.devtools.jaxb.jxcCmd example: /jck/jck11/JCK-devtools-10/linux/bin/schemagen
+jck.env.devtools.jaxb.jxcCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxb.needJaxbClasses=No
+jck.env.devtools.jaxb.skipJ2XOptional=Yes
+# jck.env.devtools.jaxb.xjcCmd=/jck/jck11/JCK-devtools-10/linux/bin/xjc
+jck.env.devtools.jaxb.xjcCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxb.xml_schema=Yes
+jck.env.devtools.jaxb=Yes
+# jck.env.devtools.jaxws.cmdJavac=/home/user/jdk/jdk10/bin/javac
+jck.env.devtools.jaxws.cmdJavac=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.jaxws.genCmd=/jck/jck11/JCK-devtools-10/linux/bin/wsgen
+jck.env.devtools.jaxws.genCmd=will_be_set_by_test_automation_at_run_time
+# jck.env.devtools.jaxws.impCmd=/jck/jck11/JCK-devtools-10/linux/bin/wsimport
+jck.env.devtools.jaxws.impCmd=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.jaxws=Yes
+# jck.env.devtools.refExecute.cmdAsFile=/home/user/jdk/jdk10/bin/java
+jck.env.devtools.refExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.refExecute.otherEnvVars=
+jck.env.devtools.refExecute.otherOpts=
+jck.env.devtools.scriptEnvVars=
+jck.env.devtools.services.autostartServices=
+jck.env.devtools.services.servicesOn=No
+jck.env.devtools.testExecute.additionalClasspath=
+jck.env.devtools.testExecute.classpath=command line option
+jck.env.devtools.testExecute.classpathEnv=CLASSPATH
+jck.env.devtools.testExecute.classpathOpt=-classpath \#
+# jck.env.devtools.testExecute.cmdAsFile=/home/user/jdk/jdk10/bin/java
+jck.env.devtools.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.devtools.testExecute.otherEnvVars=
+jck.env.devtools.testExecute.otherOpts=
+jck.env.envName=jck_devtools
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=\ncompilerModulePathOptionTemplate\=\ncompilerModuleSourcePathOptionTemplate\=\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=\nvmModulePathOptionTemplate\=\nvmAddModsOptionTemplate\=\n
+jck.env.platform=jre
+jck.env.platformModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
+jck.env.product=devtools
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyHost=
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck11/excludes/jck11.jtx\n/jck/jck11/excludes/jck11.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
+jck.keywords.needKeywords=No
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.chooseTests=Yes
+jck.tests.needTests=No
+jck.tests.setOfModules=
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/config/jck11/runtime.jti
+++ b/openjdk.test.jck/config/jck11/runtime.jti
@@ -1,0 +1,185 @@
+#JavaTest Harness Configuration Interview
+DESCRIPTION=JCK11 runtime template jti for STF automation
+INTERVIEW=com.sun.jck.interview.JCKParameters
+LOCALE=en_US
+NAME=jck_runtime
+QUESTION=jck.end
+# TESTSUITE example: /jck/jck11/JCK-runtime-11
+TESTSUITE=will_be_set_by_test_automation_at_run_time
+# WORKDIR example: /home/user/JCK-runtime-10
+WORKDIR=will_be_set_by_test_automation_at_run_time
+jck.concurrency.concurrency=1
+jck.env.description=JCK11 runtime template jti for STF automation
+jck.env.envName=jck_runtime
+jck.env.moduleSystem.compilerOptions=compilerAddModsOptionTemplate\=\ncompilerModulePathOptionTemplate\=\ncompilerModuleSourcePathOptionTemplate\=\n
+jck.env.moduleSystem.vmOptions=vmModuleEntryOptionTemplate\=--module \#\nvmModulePathOptionTemplate\=--module-path \#\nvmAddModsOptionTemplate\=--add-modules \#[,\#]\n
+jck.env.platform=jre
+jck.env.platformModules=java.base java.compiler java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.sql java.sql.rowset java.xml java.xml.crypto 
+jck.env.product=runtime
+jck.env.runtime.RemoteAgent=Yes
+jck.env.runtime.agent.networkClassLoading=No
+jck.env.runtime.agent.passivePort=
+jck.env.runtime.agent.resourcesRemoving=No
+jck.env.runtime.audio.canPlayMidi=Yes
+jck.env.runtime.audio.canPlaySound=Yes
+jck.env.runtime.audio.canRecordSound=Yes
+jck.env.runtime.audio.soundURLChoice=Yes
+jck.env.runtime.audio.soundURLYesJCK=.WAV
+jck.env.runtime.audio=Yes
+jck.env.runtime.awt.crossWindowFocusTransferSupported=Yes
+jck.env.runtime.awt.robotAvailable=Yes
+jck.env.runtime.awt.splashScreenOpt=-splash\:\#
+jck.env.runtime.awt.splashScreenSupported=Yes
+jck.env.runtime.awt=Yes
+jck.env.runtime.fp.doubleMaxExponent=
+jck.env.runtime.fp.doubleMinExponent=
+jck.env.runtime.fp.floatMaxExponent=
+jck.env.runtime.fp.floatMinExponent=
+jck.env.runtime.fp.format=Intel, 15 bit exponent
+jck.env.runtime.fp.supportExtended=Yes
+jck.env.runtime.fp=Yes
+jck.env.runtime.ftpSupport=Yes
+# jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
+jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.idl.orbPort=9876
+jck.env.runtime.idl=Yes
+jck.env.runtime.jaas.authPolicy=standard system property
+jck.env.runtime.jaas.loginConfig=standard system property
+jck.env.runtime.jaas=Yes
+jck.env.runtime.jdwp.VMSuspended=Yes
+jck.env.runtime.jdwp.connectorType=attaching
+jck.env.runtime.jdwp.jdwpOpts=-agentlib\:jdwp\=server\=y,transport\=dt_socket,address\=localhost\:35000,suspend\=y
+jck.env.runtime.jdwp.jdwpSupported=Yes
+jck.env.runtime.jdwp.transportAddress=localhost\:35000
+jck.env.runtime.jdwp.transportClass=javasoft.sqe.jck.lib.jpda.jdwp.SocketTransportService
+jck.env.runtime.jdwp=Yes
+jck.env.runtime.jgss.kdc=No
+# jck.env.runtime.jgss.kdcHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.jgss.kdcHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jgss.kdcRealm=No
+# jck.env.runtime.jgss.kdcRealmName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.jgss.kdcRealmName=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ClientPassword example: password2
+jck.env.runtime.jgss.krb5ClientPassword=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ClientUsername example: user2
+jck.env.runtime.jgss.krb5ClientUsername=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ServerPassword example: password1
+jck.env.runtime.jgss.krb5ServerPassword=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.jgss.krb5ServerUsername example: user1
+jck.env.runtime.jgss.krb5ServerUsername=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.jgss.loginModule=Yes
+jck.env.runtime.jgss=Yes
+jck.env.runtime.jplis.jplisCmdLine=Yes
+jck.env.runtime.jplis.jplisLivePhase=Yes
+jck.env.runtime.jplis.jplisLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JPLISAttachConnector
+jck.env.runtime.jplis=Yes
+jck.env.runtime.jsse.isJKSSupported=Yes
+jck.env.runtime.jsse=Yes
+jck.env.runtime.memory.expectOutOfMemory=Yes
+jck.env.runtime.memory.memoryAllocation=Yes
+jck.env.runtime.memory=Yes
+# jck.env.runtime.net.localHostIPAddr example: n.n.n.n
+jck.env.runtime.net.localHostIPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.localHostName example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.localHostName=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.other=Yes
+jck.env.runtime.net.tcpLower=
+jck.env.runtime.net.tcpRange=No
+jck.env.runtime.net.tcpUpper=
+# jck.env.runtime.net.testHost1IPAddr example: n.n.n.n
+jck.env.runtime.net.testHost1IPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost1Name example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.testHost1Name=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost2IPAddr example: n.n.n.n
+jck.env.runtime.net.testHost2IPAddr=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.net.testHost2Name example: xxxx.xxxx.xxxx.com
+jck.env.runtime.net.testHost2Name=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.net.udpLower=
+jck.env.runtime.net.udpRange=No
+jck.env.runtime.net.udpUpper=
+jck.env.runtime.net=Yes
+jck.env.runtime.print.hasPrinter=Yes
+jck.env.runtime.print=Yes
+jck.env.runtime.remoteAgent.loadClasses=No
+jck.env.runtime.remoteAgent.passiveHost=localhost
+jck.env.runtime.remoteAgent.passivePort=
+jck.env.runtime.remoteAgent.passivePortDefault=Yes
+jck.env.runtime.remoteAgent.serviceCommand=java  -cp @{testsuite}/lib/javatest.jar\:@{testsuite}/classes\:@{testsuite}/lib/jtjck.jar  -Djava.security.policy\=@{testsuite}/lib/jck.policy  -Djavatest.security.allowPropertiesAccess\=true com.sun.javatest.agent.AgentMain -passivePort @{port}
+jck.env.runtime.services.autostartServices=RMI_service ORB_service Distributed_Agent
+jck.env.runtime.services.servicesOn=No
+jck.env.runtime.testExecute.activationPortValue=
+jck.env.runtime.testExecute.additionalClasspath=
+jck.env.runtime.testExecute.classpath=command line option
+jck.env.runtime.testExecute.classpathEnv=CLASSPATH
+jck.env.runtime.testExecute.classpathOpt=-classpath \#
+# jck.env.runtime.testExecute.cmdAsFile example: /home/user/jdk10/jre/bin/java
+jck.env.runtime.testExecute.cmdAsFile=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.jarExecution=Yes
+jck.env.runtime.testExecute.jarExecutionOpt=-jar \#
+jck.env.runtime.testExecute.jmx=Yes
+# jck.env.runtime.testExecute.jmxResourcePathFileValue example: /jck/jck11/natives/linux_x86-64
+jck.env.runtime.testExecute.jmxResourcePathFileValue=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.jni=Yes
+jck.env.runtime.testExecute.jvmti=Yes
+jck.env.runtime.testExecute.jvmtiAgentOptionsTempl=-agentlib\:\#\=@
+jck.env.runtime.testExecute.jvmtiLivePhase=Yes
+jck.env.runtime.testExecute.jvmtiLivePhaseLauncherImpl=javasoft.sqe.jck.lib.attach.JVMTIAttachConnector
+jck.env.runtime.testExecute.libPath=environment variable
+# jck.env.runtime.testExecute.libPathEnv example: LD_LIBRARY_PATH
+jck.env.runtime.testExecute.libPathEnv=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.moduleOptions=Yes
+# jck.env.runtime.testExecute.nativeLibPathFileValue example: /jck/jck11/natives/linux_x86-64
+jck.env.runtime.testExecute.nativeLibPathFileValue=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.testExecute.nativeLibrariesLocation=Yes
+jck.env.runtime.testExecute.nativeLibsLinkage=dynamic
+jck.env.runtime.testExecute.optionSpecification=Yes
+jck.env.runtime.testExecute.otherEnvVars=
+jck.env.runtime.testExecute.otherOpts=
+jck.env.runtime.testExecute.rmi=Yes
+jck.env.runtime.testExecute.rmiActivationSupport=Yes
+jck.env.runtime.testExecute.stdActivationPort=Yes
+jck.env.runtime.testExecute.verify=-Xfuture
+# jck.env.runtime.url.fileURL example: file\:///home/user/urlfile.txt
+jck.env.runtime.url.fileURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.ftpURL example: ftp\://user\:password@xxxx.xxxx.xxxx.com/xxx.txt
+jck.env.runtime.url.ftpURL=will_be_set_by_test_automation_at_run_time
+# jck.env.runtime.url.httpURL example: http\://xxxx.xxxx.xxxx.com/index.html
+jck.env.runtime.url.httpURL=will_be_set_by_test_automation_at_run_time
+jck.env.runtime.url=Yes
+jck.env.simpleOrAdvanced=advanced
+# jck.env.testPlatform.display example: ':1' or xxxx.xxxx.xxxx.com\:0.0
+jck.env.testPlatform.display=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.headless=No
+jck.env.testPlatform.jvmti=Yes
+jck.env.testPlatform.multiJVM=Yes
+jck.env.testPlatform.nativeCode=Yes
+jck.env.testPlatform.needProxy=No
+jck.env.testPlatform.os=Current system
+jck.env.testPlatform.processCreationSupport=Yes
+jck.env.testPlatform.proxyPort=
+jck.env.testPlatform.remoteNetworking=Remote network support
+# jck.env.testPlatform.systemRoot example: C\:\\WINDOWS
+jck.env.testPlatform.systemRoot=will_be_set_by_test_automation_at_run_time
+jck.env.testPlatform.typecheckerSpecific=Yes
+jck.env.testPlatform.useAgent=No
+# jck.excludeList.customFiles example: /jck/jck11/excludes/jck11.jtx\n/jck/jck11/excludes/jck11.kfl
+jck.excludeList.customFiles=will_be_set_by_test_automation_at_run_time
+jck.excludeList.excludeListType=custom
+jck.excludeList.latestAutoCheck=No
+jck.excludeList.latestAutoCheckInterval=7
+jck.excludeList.latestAutoCheckMode=everyXDays
+jck.excludeList.needExcludeList=Yes
+jck.keywords.keywords.mode=expr
+jck.keywords.keywords.value=\!interactive
+jck.keywords.keywords=\!interactive
+jck.keywords.needKeywords=Yes
+jck.knownFailuresList.customFiles=
+jck.knownFailuresList.needKfl=No
+jck.priorStatus.needStatus=No
+jck.priorStatus.status=
+jck.tests.chooseTests=Yes
+jck.tests.needTests=No
+jck.tests.setOfModules=java.activation java.base java.compiler java.corba java.datatransfer java.desktop java.instrument java.logging java.management java.management.rmi java.naming java.prefs java.rmi java.scripting java.se java.security.jgss java.security.sasl java.se.ee java.sql java.sql.rowset java.transaction java.xml java.xml.bind java.xml.crypto java.xml.ws java.xml.ws.annotation
+jck.tests.tests=
+jck.tests.treeOrFile=tree
+jck.timeout.timeout=1

--- a/openjdk.test.jck/include/test_targets.mk
+++ b/openjdk.test.jck/include/test_targets.mk
@@ -5520,6 +5520,1267 @@ test.jck10.devtools.schema_bind.bind_schemaBindings:
 	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_schemaBindings,jckversion=jck10,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
 	echo Target $@ completed
 
+# Targets to run jck11
+
+# Targets for the jck11 runtime test suite
+JCK11_RUNTIME_TESTS:= \
+test.jck11.runtime.api.java_math \
+test.jck11.runtime.api.java_security \
+test.jck11.runtime.api.java_sql \
+test.jck11.runtime.api.java_text \
+test.jck11.runtime.api.javax_activation \
+test.jck11.runtime.api.javax_activity \
+test.jck11.runtime.api.javax_annotation \
+test.jck11.runtime.api.javax_crypto \
+test.jck11.runtime.api.javax_imageio \
+test.jck11.runtime.api.javax_lang \
+test.jck11.runtime.api.javax_net \
+test.jck11.runtime.api.javax_script \
+test.jck11.runtime.api.javax_security \
+test.jck11.runtime.api.javax_sql \
+test.jck11.runtime.api.javax_tools \
+test.jck11.runtime.api.javax_transaction \
+test.jck11.runtime.api.org_w3c \
+test.jck11.runtime.api.org_xml \
+test.jck11.runtime.api.serializabletypes \
+test.jck11.runtime.api.signaturetest \
+test.jck11.runtime.api.xinclude \
+test.jck11.runtime.api.xsl \
+test.jck11.runtime.api.java_applet \
+test.jck11.runtime.api.java_awt \
+test.jck11.runtime.api.java_beans \
+test.jck11.runtime.api.java_io \
+test.jck11.runtime.api.java_util \
+test.jck11.runtime.api.javax_accessibility \
+test.jck11.runtime.api.javax_naming \
+test.jck11.runtime.api.javax_print \
+test.jck11.runtime.api.javax_sound \
+test.jck11.runtime.api.javax_swing \
+test.jck11.runtime.api.java_lang \
+test.jck11.runtime.api.java_net \
+test.jck11.runtime.api.java_nio \
+test.jck11.runtime.api.java_rmi \
+test.jck11.runtime.api.javax_management \
+test.jck11.runtime.api.javax_rmi \
+test.jck11.runtime.api.javax_xml \
+test.jck11.runtime.api.modulegraph \
+test.jck11.runtime.api.org_omg \
+test.jck11.runtime.api.org_ietf \
+test.jck11.runtime.api.java_time \
+test.jck11.runtime.vm.cldc \
+test.jck11.runtime.vm.concepts \
+test.jck11.runtime.vm.constantpool \
+test.jck11.runtime.vm.fp \
+test.jck11.runtime.vm.jvmti \
+test.jck11.runtime.vm.module \
+test.jck11.runtime.vm.overview \
+test.jck11.runtime.vm.typechecker \
+test.jck11.runtime.vm.classfmt \
+test.jck11.runtime.vm.instr \
+test.jck11.runtime.vm.jni \
+test.jck11.runtime.vm.jdwp \
+test.jck11.runtime.xopts.vm.cldc \
+test.jck11.runtime.xopts.vm.concepts \
+test.jck11.runtime.xopts.vm.constantpool \
+test.jck11.runtime.xopts.vm.fp \
+test.jck11.runtime.xopts.vm.jvmti \
+test.jck11.runtime.xopts.vm.overview \
+test.jck11.runtime.xopts.vm.typechecker \
+test.jck11.runtime.xopts.vm.classfmt \
+test.jck11.runtime.xopts.vm.instr \
+test.jck11.runtime.xopts.vm.jni \
+test.jck11.runtime.xopts.vm.jdwp \
+test.jck11.runtime.lang.ANNOT \
+test.jck11.runtime.lang.ARR \
+test.jck11.runtime.lang.BINC \
+test.jck11.runtime.lang.CLSS \
+test.jck11.runtime.lang.CONV \
+test.jck11.runtime.lang.DASG \
+test.jck11.runtime.lang.EXCP \
+test.jck11.runtime.lang.EXEC \
+test.jck11.runtime.lang.EXPR \
+test.jck11.runtime.lang.FP \
+test.jck11.runtime.lang.ICLS \
+test.jck11.runtime.lang.INTF \
+test.jck11.runtime.lang.LEX \
+test.jck11.runtime.lang.NAME \
+test.jck11.runtime.lang.PKGS \
+test.jck11.runtime.lang.STMT \
+test.jck11.runtime.lang.THRD \
+test.jck11.runtime.lang.TYPE \
+test.jck11.runtime.lang.INFR \
+test.jck11.runtime.lang.LMBD \
+test.jck11.runtime.xml_schema.msdata.additional \
+test.jck11.runtime.xml_schema.msdata.annotations \
+test.jck11.runtime.xml_schema.msdata.attribute \
+test.jck11.runtime.xml_schema.msdata.attributeGroup \
+test.jck11.runtime.xml_schema.msdata.complexType \
+test.jck11.runtime.xml_schema.msdata.datatypes \
+test.jck11.runtime.xml_schema.msdata.element \
+test.jck11.runtime.xml_schema.msdata.errata10 \
+test.jck11.runtime.xml_schema.msdata.group \
+test.jck11.runtime.xml_schema.msdata.identityConstraint \
+test.jck11.runtime.xml_schema.msdata.modelGroups \
+test.jck11.runtime.xml_schema.msdata.notations \
+test.jck11.runtime.xml_schema.msdata.particles \
+test.jck11.runtime.xml_schema.msdata.regex \
+test.jck11.runtime.xml_schema.msdata.schema \
+test.jck11.runtime.xml_schema.msdata.simpleType \
+test.jck11.runtime.xml_schema.msdata.wildcards \
+test.jck11.runtime.xml_schema.nistdata.atomic \
+test.jck11.runtime.xml_schema.nistdata.list \
+test.jck11.runtime.xml_schema.nistdata.union \
+test.jck11.runtime.xml_schema.sundata \
+test.jck11.runtime.xml_schema.boeingData
+# Allow the user to exclude tests from the command line
+JCK11_RUNTIME_TESTS:=$(filter-out $(EXCLUDE),$(JCK11_RUNTIME_TESTS))
+
+JCK11_TESTS_REQUIRING_CONFIG:=\
+test.jck11.runtime.api.java_net \
+test.jck11.runtime.api.java_nio \
+test.jck11.runtime.api.org_ietf \
+test.jck11.runtime.api.javax_security
+# Allow the user to exclude tests from the command line
+JCK11_TESTS_REQUIRING_CONFIG:=$(filter-out $(EXCLUDE),$(JCK11_TESTS_REQUIRING_CONFIG))
+
+JCK11_RUNTIME_TESTS_NO_CONFIG:=$(filter-out $(JCK11_TESTS_REQUIRING_CONFIG),$(JCK11_RUNTIME_TESTS))
+
+# Targets for the jck11 compiler test suite
+JCK11_COMPILER_TESTS:= \
+test.jck11.compiler.api.java_rmi \
+test.jck11.compiler.api.javax_annotation \
+test.jck11.compiler.api.javax_lang \
+test.jck11.compiler.api.javax_tools \
+test.jck11.compiler.api.signaturetest \
+test.jck11.compiler.lang.ANNOT \
+test.jck11.compiler.lang.ARR  \
+test.jck11.compiler.lang.BINC  \
+test.jck11.compiler.lang.CLSS  \
+test.jck11.compiler.lang.CONV  \
+test.jck11.compiler.lang.DASG  \
+test.jck11.compiler.lang.EXCP  \
+test.jck11.compiler.lang.EXEC  \
+test.jck11.compiler.lang.EXPR  \
+test.jck11.compiler.lang.FP  \
+test.jck11.compiler.lang.ICLS  \
+test.jck11.compiler.lang.INTF  \
+test.jck11.compiler.lang.LEX  \
+test.jck11.compiler.lang.NAME  \
+test.jck11.compiler.lang.PKGS  \
+test.jck11.compiler.lang.STMT  \
+test.jck11.compiler.lang.THRD  \
+test.jck11.compiler.lang.TYPE \
+test.jck11.compiler.lang.INFR \
+test.jck11.compiler.lang.LMBD \
+test.jck11.compiler.lang.MOD
+# Allow the user to exclude tests from the command line
+JCK11_COMPILER_TESTS:=$(filter-out $(EXCLUDE),$(JCK11_COMPILER_TESTS))
+
+# Targets for the jck11 devtools test suite
+JCK11_DEVTOOLS_TESTS:=
+# Allow the user to exclude tests from the command line
+JCK11_DEVTOOLS_TESTS:=$(filter-out $(EXCLUDE),$(JCK11_DEVTOOLS_TESTS))
+
+# All the JCK11 tests
+JCK11_TESTS:=$(JCK11_RUNTIME_TESTS) \
+$(JCK11_COMPILER_TESTS) \
+$(JCK11_DEVTOOLS_TESTS)
+
+# The tests which do not require http or kerberos setup
+JCK11_TESTS_NO_CONFIG:=$(filter-out $(JCK11_TESTS_REQUIRING_CONFIG),$(JCK11_TESTS))
+
+.PHONY: \
+test.jck.custom
+
+.PHONY: \
+test.jck11 \
+test.jck11.noconfig \
+test.jck11.compiler.custom \
+test.jck11.compiler.api \
+test.jck11.compiler.lang \
+test.jck11.devtools.custom \
+test.jck11.devtools.java2schema \
+test.jck11.devtools.jaxws \
+test.jck11.devtools.schema2java \
+test.jck11.devtools.schema_bindtest \
+test.jck11.devtools.xml_schema \
+test.jck11.runtime.custom \
+test.jck11.runtime.api \
+test.jck11.runtime.lang \
+test.jck11.runtime.vm \
+test.jck11.runtime.xml_schema \
+test.jck11.runtime.api.in.parts \
+test.jck11.runtime.api.noconfig
+
+# Target to run Java 10 Runtime JCK tests in one run but in smaller parts.
+test.jck11.runtime.api.in.parts: $(JCK11_RUNTIME_TESTS)
+# Target to run Java 10 Runtime JCK tests excluding the parts which require Kerberos and Http server setup
+test.jck11.runtime.api.noconfig: $(JCK11_RUNTIME_TESTS_NO_CONFIG)
+
+# Target to run tests from any JCK test directory
+test.jck.custom:
+	echo Running target $@ with custom jck test $(JCKTEST), jckversion $(JCKVERSION), testsuite $(JCKTESTSUITE) $(JCKCONCURRENCY_ARG)
+	$(STF_COMMAND) -test=Jck -test-args="tests=$(JCKTEST),jckversion=$(JCKVERSION),testsuite=$(JCKTESTSUITE)$(JCKCONCURRENCY_ARG)" $(LOG)
+	echo Target $@ completed
+
+# jck11 targets
+# Targets to run all Java 10 JCK in small parts
+test.jck11: $(JCK11_TESTS)
+# Target to run Java 10 JCK tests excluding the parts which require Kerberos and Http server setup
+test.jck11.noconfig: $(JCK11_TESTS_NO_CONFIG)
+
+# Targets to run tests from any jck11 runtime, compiler or devtools test directory
+test.jck11.runtime.custom:
+	echo Running target $@ with custom jck test ${JCKTEST}
+	$(STF_COMMAND) -test=Jck -test-args="tests=${JCKTEST},jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.custom:
+	echo Running target $@ with custom jck test ${JCKTEST}
+	$(STF_COMMAND) -test=Jck -test-args="tests=${JCKTEST},jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.custom:
+	echo Running target $@ with custom jck test ${JCKTEST}
+	$(STF_COMMAND) -test=Jck -test-args="tests=${JCKTEST},jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_ARG)" $(LOG)
+	echo Target $@ completed
+
+# Targets to run Java 10 JCK in very large pieces
+test.jck11.runtime.api:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.runtime.lang:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.runtime.vm:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.runtime.xml_schema:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.api:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.java2schema:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=java2schema,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.jaxws:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=jaxws,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema2java:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema2java,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+
+
+# Target to run Java 10 Runtime JCK tests in one run but in smaller parts.
+test.jck11.runtime.api.in.parts: $(JCK11_RUNTIME_TESTS)
+# Target to run Java 10 Runtime JCK tests excluding the parts which require Kerberos and Http server setup
+test.jck11.runtime.api.noconfig: $(JCK11_RUNTIME_TESTS_NO_CONFIG)
+
+# Target to run the interactive tests
+test.jck11.runtime.api.interactive:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api,jckversion=jck11,testsuite=RUNTIME,interactive=yes" $(LOG)
+	@echo Target $@ completed
+
+# Targets to run runtime test suites individually
+test.jck11.runtime.api.java_math:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_math,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_security:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_security,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_sql:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_sql,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_text:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_text,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_activation:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_activation,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_activity:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_activity,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_annotation:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_annotation,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_crypto:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_crypto,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_imageio:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_imageio,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_lang:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_lang,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_net:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_net,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_script:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_script,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_security:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_security,jckversion=jck11,testsuite=RUNTIME,config=$(JCK_CONFIG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_sql:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_sql,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_tools:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_tools,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_transaction:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_transaction,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.org_w3c:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/org_w3c,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.serializabletypes:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/serializabletypes,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.org_xml:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/org_xml,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.signaturetest:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/signaturetest,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.xinclude:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/xinclude,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.xsl:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/xsl,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_applet:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_applet,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_awt:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_awt,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_beans:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_beans,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_io:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_io,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_util:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_util,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_accessibility:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_accessibility,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_naming:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_naming,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_print:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_print,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_sound:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_sound,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_swing:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_swing,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_lang:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_lang,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_net:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_net,jckversion=jck11,testsuite=RUNTIME,config=$(JCK_CONFIG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_nio:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_nio,jckversion=jck11,testsuite=RUNTIME,config=$(JCK_CONFIG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_rmi:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_rmi,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_management:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_management,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_rmi:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_rmi,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.javax_xml:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_xml,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.modulegraph:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/modulegraph,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.org_omg:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/org_omg,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.org_ietf:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/org_ietf,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG),config=$(JCK_CONFIG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.api.java_time:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_time,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.cldc:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/cldc,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.concepts:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/concepts,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.constantpool:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/constantpool,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.fp:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/fp,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.jvmti:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jvmti,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.module:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/module,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.overview:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/overview,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.typechecker:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/typechecker,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.classfmt:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/classfmt,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.instr:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/instr,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.jni:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jni,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.vm.jdwp:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jdwp,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.cldc:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/cldc,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.concepts:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/concepts,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.constantpool:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/constantpool,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.fp:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/fp,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.jvmti:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jvmti,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.overview:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/overview,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.typechecker:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/typechecker,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.classfmt:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/classfmt,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.instr:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/instr,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.jni:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jni,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xopts.vm.jdwp:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=vm/jdwp,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_1_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.ANNOT:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ANNOT,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.ARR:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ARR,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.BINC :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/BINC,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.CLSS :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/CLSS,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.CONV :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/CONV,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.DASG :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/DASG,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.EXCP :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXCP,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.EXEC :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXEC,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.EXPR :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXPR,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.FP :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/FP,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.ICLS :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ICLS,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.INTF :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/INTF,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.LEX :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/LEX,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.NAME :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/NAME,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.PKGS :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/PKGS,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.STMT :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/STMT,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.THRD :
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/THRD,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.TYPE:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/TYPE,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.INFR:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/INFR,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.lang.LMBD:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/LMBD,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.additional:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/additional,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.annotations:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/annotations,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.attribute:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/attribute,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.attributeGroup:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/attributeGroup,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.complexType:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/complexType,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.datatypes:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/datatypes,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.element:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/element,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.errata10:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/errata10,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.group:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/group,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.identityConstraint:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/identityConstraint,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.modelGroups:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/modelGroups,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.notations:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/notations,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.particles:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/particles,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.regex:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/regex,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.schema:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/schema,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.simpleType:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/simpleType,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.msdata.wildcards:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/wildcards,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.nistdata.atomic:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.nistdata.list:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.nistdata.union:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/union,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.sundata:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/sunData,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+test.jck11.runtime.xml_schema.boeingData:
+	@echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/boeingData,jckversion=jck11,testsuite=RUNTIME$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	@echo Target $@ completed
+
+# Targets to run compiler test suites individually
+test.jck11.compiler.api.java_rmi:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/java_rmi,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.api.javax_annotation:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_annotation,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.api.javax_lang:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_lang,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.api.javax_tools:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/javax_tools,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.api.signaturetest:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=api/signaturetest,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.ANNOT:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ANNOT,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.ARR :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ARR,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.BINC :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/BINC,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.CLSS :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/CLSS,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.CONV :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/CONV,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.DASG :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/DASG,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.EXCP :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXCP,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.EXEC :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXEC,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.EXPR :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/EXPR,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.FP :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/FP,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.ICLS :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/ICLS,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.INTF :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/INTF,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.LEX :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/LEX,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.NAME :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/NAME,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.PKGS :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/PKGS,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.STMT :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/STMT,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.THRD :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/THRD,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.TYPE:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/TYPE,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.INFR:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/INFR,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.LMBD:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/LMBD,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.compiler.lang.MOD:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=lang/MOD,jckversion=jck11,testsuite=COMPILER$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+
+# Targets to run devtools test suites individually
+# java2schema already defined above, not broken down further
+#test.jck11.devtools.java2schema:
+#	echo Running target $@
+#	$(STF_COMMAND) -test=Jck -test-args="tests=java2schema,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+#	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.additional:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/additional,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.annotations:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/annotations,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.attribute :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/attribute,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.attributeGroup:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/attributeGroup,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.complexType :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/complexType,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.datatypes :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/datatypes,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.element :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/element,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.errata10 :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/errata10,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.group :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/group,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.identityConstraint :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/identityConstraint,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.modelGroups :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/modelGroups,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.notations :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/notations,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.particles :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/particles,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.regex :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/regex,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.schema:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/schema,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.simpleType :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/simpleType,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.msData.wildcards:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/msData/wildcards,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.anyURI:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/anyURI,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.base64Binary :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/base64Binary,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.boolean:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/boolean,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.byte:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/byte,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.date:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/date,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.dateTime :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/dateTime,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.decimal :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/decimal,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.double:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/double,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.duration :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/duration,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.float:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/float,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.gDay:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gDay,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.gMonth :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gMonth,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.gMonthDay:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gMonthDay,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.gYear:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gYear,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.gYearMonth:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/gYearMonth,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.hexBinary:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/hexBinary,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.ID:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/ID,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.int:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/int,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.integer:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/integer,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.language:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/language,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.long:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/long,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.Name:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/Name,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.NCName:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/NCName,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.negativeInteger:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/negativeInteger,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.NMTOKEN :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/NMTOKEN,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.nonNegativeInteger:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/nonNegativeInteger,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.nonPositiveInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/nonPositiveInteger,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.normalizedString:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/normalizedString,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.positiveInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/positiveInteger,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.QName:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/QName,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.short:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/short,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.string:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/string,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.time:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/time,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.token:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/token,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.unsignedByte:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/unsignedByte,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.unsignedInt :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/unsignedInt,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.unsignedLong:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/unsignedLong,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.atomic.unsignedShort:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/atomic/unsignedShort,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.anyURI:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/anyURI,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.base64Binary:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/base64Binary,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.boolean:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/boolean,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.byte:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/byte,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.date:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/date,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.dateTime:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/dateTime,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.decimal:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/decimal,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.double:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/double,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.duration:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/duration,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.float:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/float,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.gDay :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gDay,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.gMonth :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gMonth,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.gMonthDay :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gMonthDay,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.gYear:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gYear,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.gYearMonth:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/gYearMonth,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.hexBinary :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/hexBinary,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.ID :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/ID,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.int:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/int,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.integer :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/integer,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.language :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/language,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.long:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/long,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.Name   :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/Name,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.NCName:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/NCName,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.negativeInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/negativeInteger,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.NMTOKEN:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/NMTOKEN,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.NMTOKENS:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/NMTOKENS,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.nonNegativeInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/nonNegativeInteger,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.nonPositiveInteger :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/nonPositiveInteger,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.normalizedString:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/normalizedString,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.positiveInteger:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/positiveInteger,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.QName :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/QName,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.short:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/short,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.string:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/string,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.time:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/time,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.token:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/token,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.unsignedByte:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/unsignedByte,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.unsignedInt:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/unsignedInt,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.unsignedLong:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/unsignedLong,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.list.unsignedShort:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/list/unsignedShort,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.nistData.union:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/nistData/union,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.sunData:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/sunData,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.xml_schema.boeingData:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=xml_schema/boeingData,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+# jaxws already defined above, not broken down further
+#test.jck11.devtools.jaxws:
+#	echo Running target $@
+#	$(STF_COMMAND) -test=Jck -test-args="tests=jaxws,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+#	echo Target $@ completed
+test.jck11.devtools.schema2java.nisttest:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema2java/nisttest,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema2java.structures:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema2java/structures,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind.bind_class :
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_class,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind.bind_dom:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_dom,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind.bind_globalBindings:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_globalBindings,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind.bind_property:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_property,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind.bind_factoryMethod:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_factoryMethod,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind.bind_inlineBinaryData:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_inlineBinaryData,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind.bind_javaType:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_javaType,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+test.jck11.devtools.schema_bind.bind_schemaBindings:
+	echo Running target $@
+	$(STF_COMMAND) -test=Jck -test-args="tests=schema_bind/bind_schemaBindings,jckversion=jck11,testsuite=DEVTOOLS$(JCKCONCURRENCY_CPUS_ARG)" $(LOG)
+	echo Target $@ completed
+
 help.jck:
 	@echo -------------------------------------------------------------------------------
 	@echo Help for JCK tests

--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -317,7 +317,8 @@ public class Jck implements StfPluginInterface {
 			StfProcess tnameserv = null;
 			
 			String executeJar;
-			if ((jckVersion.contains("jck10") ||
+			if ((jckVersion.contains("jck11") ||
+				 jckVersion.contains("jck10") ||
 				 jckVersion.contains("jck9") ||
 				 jckVersion.contains("jck8")) &&
 				 (testSuite == TestSuite.RUNTIME) ) {
@@ -886,7 +887,7 @@ public class Jck implements StfPluginInterface {
 	private String getTestSpecificJvmOptions (String jckVersion, String tests) {
 		String testSpecificJvmOptions = "";
 		// --add-modules options are required to make some modules visible for Java 9 onwards.
-		if (jckVersion.contains("jck9") || jckVersion.contains("jck10")) {
+		if (jckVersion.contains("jck9") || jckVersion.contains("jck10") || jckVersion.contains("jck11")) {
 			// If the top level api node is being run, add all modules required by the api tests
 			if (tests.equals("api")) {
 				testSpecificJvmOptions = " --add-modules java.activation,java.corba,java.xml.crypto,java.xml.ws.annotation,java.se.ee,java.sql,java.transaction,java.xml.bind,java.xml.ws";


### PR DESCRIPTION
Enable `JCK11` test

Initial addition to run `JCK11` tests based on `JCK10` setup.

Manually verified that `make _jck-runtime-api-java_lang-String` and `make _jck-runtime-custom  JCK_TEST_TARGET=api/java_math` are working.

Related to https://github.com/AdoptOpenJDK/openjdk-tests/pull/507

Reviewer @smlambert 
FYI: @DanHeidinga @pshipton @llxia 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>