### PR TITLE
Skip using javax.transaction.* and CORBA classes  for load test while on Java 11 and up

### DIFF
--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
@@ -41,7 +41,8 @@ public class ClassHog
 
 			ClassLoader classLoader = getClass().getClassLoader();
 			FileReader dictFileReader = new FileReader(classLoader.getResource("net/adoptopenjdk/test/classloading/" +  dictFileName).getFile());
-
+			int javaVersion = Integer.parseInt(System.getProperty("java.version.number"));
+			
 			// open the dictionary file
 			BufferedReader br = new BufferedReader(dictFileReader);
 			// get a line at a time
@@ -49,6 +50,12 @@ public class ClassHog
 			{
 				try
 				{
+					if (javaVersion >= 11) {
+						// javax.transaction and CORBA has been removed from Java 11
+						if ( s.startsWith("javax.transaction") || s.startsWith("org.omg") ) {
+							continue;
+						}
+					}
 					// use the class loader to get the Class class that represents the class on the current line
 					c = Class.forName (s);
 					cnt++;

--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
@@ -84,14 +84,23 @@ public class ClassMapHog
 				
 				ClassLoader classLoader = getClass().getClassLoader();
 				FileReader dictFileReader = new FileReader(classLoader.getResource("net/adoptopenjdk/test/classloading/" + dictFileName).getFile());
+				int javaVersion = Integer.parseInt(System.getProperty("java.version.number"));
 
 				// open the dictionary
 				BufferedReader br = new BufferedReader (dictFileReader);
+
 				// read a class line at a time
 				while ((s=br.readLine())!=null)
 				{
 					try
 					{
+						if (javaVersion >= 11) {
+							// javax.transaction and CORBA has been removed from Java 11
+							if ( s.startsWith("javax.transaction") || s.startsWith("org.omg") ) {
+								continue;
+							}
+						}
+					
 						// get the class loader to load the current class
 						// Class is the class that represents a classes 'blueprint'
 						c = Class.forName (s);

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ClassloadingLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ClassloadingLoadTest.java
@@ -66,6 +66,7 @@ public class ClassloadingLoadTest implements StfPluginInterface {
 		}
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addJvmOption("-Djava.classloading.dir=" + notonclasspathDirRoot)  // Expose the bin_notonclasspath root directory to the deadlock test
+				.addJvmOption("-Djava.version.number=" + javaVersion)
 				.addModules(modulesAdd)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)


### PR DESCRIPTION
Resolves https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/169
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>