### PR TITLE
Correct the lib path for the RPM-installed JREs

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -458,7 +458,7 @@ public class Jck implements StfPluginInterface {
 		
 		sb.append(locateFileOrFolder(root,".jar"));
 		
-		String newRoot = root.replaceAll("lib", "bin");
+		String newRoot = new File(root).getParent() + File.separator + "bin";
 		logger.info("Looking for vm.jar in " + newRoot + " for signaturetest.");
 		sb.append(locateFileOrFolder(newRoot,"vm.jar"));
 		


### PR DESCRIPTION
Installation path of RPM/DEB may contain "lib" prefix.
runtime/compiler.api.signaturetest scan the lib path to get jars.

this is for issue #205 