### PR TITLE
Parameterize inactivityLimit for LambdaLoadTest

### DIFF
--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/LambdaLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/LambdaLoadTest.java
@@ -42,11 +42,13 @@ public class LambdaLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openjdk.test.lambdasAndStreams")
+				.setInactivityLimit("60m")                  // Since this test is run using -Xint as well, set a larger inactivity limit than default 
 				.addSuite("lambda")				  			// Start args for the first suite
 				.setSuiteThreadCount(cpuCount - 2, 2)		// Leave 1 cpu for the JIT, 1 cpu for GC and set min 2
 				.setSuiteInventory(inventoryFile) 			// Point at the file which lists the tests
 				.setSuiteNumTests(200)         				// Run this many tests
 				.setSuiteRandomSelection();		  			// Randomly pick the next test each time
+				
 		
 		test.doRunForegroundProcess("Run lambda and stream load test", "LT", Echo.ECHO_ON,
 				ExpectedOutcome.cleanRun().within("60m"), 


### PR DESCRIPTION
Sets an inactivity limit of 60m for LambdaLoadTest
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>