### PR TITLE
Disable generation of coredumps at load test failure by default to save space

### DIFF
--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ClassloadingLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ClassloadingLoadTest.java
@@ -71,6 +71,7 @@ public class ClassloadingLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openjdk.test.classloading")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.setAbortIfOutOfMemory(false)
 				.addSuite("classloading")
 				.setSuiteThreadCount(cpuCount - 1, 10)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ConcurrentLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ConcurrentLoadTest.java
@@ -44,6 +44,7 @@ public class ConcurrentLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openjdk.test.concurrent")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.setAbortIfOutOfMemory(false)
 				.addSuite("concurrent")
 				.setSuiteThreadCount(cpuCount - 2, 20)	  	// Leave 1 cpu for the JIT. i for GC and set min 20

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/DirectByteBufferLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/DirectByteBufferLoadTest.java
@@ -58,6 +58,7 @@ public class DirectByteBufferLoadTest implements StfPluginInterface {
 				.addJarToClasspath(filesystemJar)
 				.addProjectToClasspath("openjdk.test.gc")
 				.addProjectToClasspath("openjdk.test.nio")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("DirectByteBuffer")
 				.setSuiteThreadCount(cpuCount - 1, 2) 
 				.setSuiteNumTests(numTests)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/LambdaLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/LambdaLoadTest.java
@@ -42,6 +42,7 @@ public class LambdaLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openjdk.test.lambdasAndStreams")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.setInactivityLimit("60m")                  // Since this test is run using -Xint as well, set a larger inactivity limit than default 
 				.addSuite("lambda")				  			// Start args for the first suite
 				.setSuiteThreadCount(cpuCount - 2, 2)		// Leave 1 cpu for the JIT, 1 cpu for GC and set min 2

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/LangLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/LangLoadTest.java
@@ -48,6 +48,7 @@ public class LangLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openjdk.test.lang")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("lang")
 				.setSuiteThreadCount(cpuCount - 1, 2)
 				.setSuiteNumTests(numlangTests * 100)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/LockingLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/LockingLoadTest.java
@@ -50,6 +50,7 @@ public class LockingLoadTest implements StfPluginInterface {
 				.addProjectToClasspath("openjdk.test.lang")  // For mini-mix inventory
 				.addProjectToClasspath("openjdk.test.util")  // For mini-mix inventory
 				.addProjectToClasspath("openjdk.test.math")  // For mini-mix inventory
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.setTimeLimit("30s")
 				.addSuite("mini-mix")
 				.setSuiteThreadCount(2)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MathLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MathLoadTest.java
@@ -77,6 +77,7 @@ public class MathLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openjdk.test.math")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("math")
 				.setSuiteThreadCount(cpuCount - 1, 2)
 				.setSuiteNumTests(numMathTests * workload.multiplier)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveMultiThreadLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveMultiThreadLoadTest.java
@@ -67,6 +67,7 @@ public class MauveMultiThreadLoadTest implements StfPluginInterface {
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addJvmOption(modularityOptions)
 				.addJarToClasspath(mauveJar)
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("mauve")
 				.setSuiteInventory(inventoryFile)
 				.setSuiteThreadCount(cpuCount - 1, 3)   // Leave 1 cpu for the JIT and one for GC, but min 2

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleInvocationLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleInvocationLoadTest.java
@@ -67,6 +67,7 @@ public class MauveSingleInvocationLoadTest implements StfPluginInterface {
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addJvmOption(modularityOptions)
 				.addJarToClasspath(mauveJar)
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("mauve")
 				.setSuiteInventory(inventoryFile)
 				.setSuiteThreadCount(1)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleThreadLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleThreadLoadTest.java
@@ -67,6 +67,7 @@ public class MauveSingleThreadLoadTest implements StfPluginInterface {
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addJvmOption(modularityOptions)
 				.addJarToClasspath(mauveJar)
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("mauve")
 				.setSuiteInventory(inventoryFile)
 				.setSuiteThreadCount(1)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/NioLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/NioLoadTest.java
@@ -67,6 +67,7 @@ public class NioLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addJarToClasspath(fileSystemJar)
 				.addProjectToClasspath("openjdk.test.nio")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.addSuite("nio")
 				.setSuiteThreadCount(cpuCount - 2, 2)		// Leave 1 cpu for the JIT, 1 cpu for GC and set min 2
 				.setSuiteNumTests(numNioTests * 10)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/SerializationLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/SerializationLoadTest.java
@@ -44,6 +44,7 @@ public class SerializationLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openjdk.test.serialization")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.setAbortIfOutOfMemory(false)
 				.addSuite("serialization")
 				.setSuiteThreadCount(cpuCount - 1, 2)	  	// Leave 1 cpu for the JIT and set min 2

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/UtilLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/UtilLoadTest.java
@@ -44,6 +44,7 @@ public class UtilLoadTest implements StfPluginInterface {
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addProjectToClasspath("openjdk.test.util")
+				.generateCoreDumpAtFirstLoadTestFailure(false)
 				.setAbortIfOutOfMemory(false)
 				.addSuite("util")
 				.setSuiteThreadCount(cpuCount - 1, 2)	  	// Leave 1 cpu for the JIT and set min 2


### PR DESCRIPTION
Disable generation of coredumps at load test failure by default to save space
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>