### PR TITLE
Add space after -o option in JlinkTest makefile

### DIFF
--- a/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
+++ b/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
@@ -236,7 +236,7 @@ jni: $(DESTDIR) $(OBJDIR) $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX)
 
 $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX): $(OBJDIR)/$(SRC)$(OSUFFIX)
 # Build the shared library
-	$(CMD_PREFIX) $(LD) $(LFLAGS)$(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX) $(OBJDIR)/$(SRC)$(OSUFFIX)
+	$(CMD_PREFIX) $(LD) $(LFLAGS) $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX) $(OBJDIR)/$(SRC)$(OSUFFIX)
 # chmod might return non zero if there is a file or directory the current user doesn't own,
 # so tell make to ignore failures
 ifneq ($(WIN),1)


### PR DESCRIPTION
Add space after -o option in JlinkTest makefile
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>