### PR TITLE
Add space after -o only while on osx

### DIFF
--- a/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
+++ b/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
@@ -236,7 +236,11 @@ jni: $(DESTDIR) $(OBJDIR) $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX)
 
 $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX): $(OBJDIR)/$(SRC)$(OSUFFIX)
 # Build the shared library
+ifeq ($(PLATFORM),osx_x86-64)
+	$(CMD_PREFIX) $(LD) $(LFLAGS) $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX) $(OBJDIR)/$(SRC)$(OSUFFIX)
+else
 	$(CMD_PREFIX) $(LD) $(LFLAGS)$(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX) $(OBJDIR)/$(SRC)$(OSUFFIX)
+endif
 # chmod might return non zero if there is a file or directory the current user doesn't own,
 # so tell make to ignore failures
 ifneq ($(WIN),1)


### PR DESCRIPTION
Fixes https://github.com/eclipse/openj9-systemtest/issues/81
Signed-off-by: Mesbah_Alam@ca.ibm.com Mesbah_Alam@ca.ibm.com