### PR TITLE
Disable failing mauve subtests:java.text.MessageFormat.format14, java.lang.System.arraycopy

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -24,6 +24,11 @@
 		 java.lang.IllegalArgumentException: Illegal pattern  character 'j'
 	-->
 	<mauve class="gnu.testlet.java.text.SimpleDateFormat.applyLocalizedPattern"/>
+	<!-- The following tests fail on Hotspot Java 11 on aarch64 with 
+		 FAIL: gnu.testlet.java.lang.System.arraycopy: Object casting (number 0)
+		 Permanently excluded, ref: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/237
+	-->
+	<mauve class="gnu.testlet.java.lang.System.arraycopy"/>
 	<!-- Fails on Oracle Java 9 with
 		 Suite number  = 0
 		 Thread number = 1

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -10,6 +10,11 @@
 		 got dir/ but expected dir
 	-->
 	<mauve class="gnu.testlet.java.util.zip.ZipFile.DirEntryTest"/>
+	<!-- Fails on AIX on OpenJ9 Java 12 with
+		 FAIL: gnu.testlet.java.text.MessageFormat.format14: time (number 3)
+		 Permanently excluded, ref: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/237
+	-->
+	<mauve class="gnu.testlet.java.text.MessageFormat.format14"/>
 	<!-- Fails on IBM and Oracle Java 9 with 
 		 Exception in thread "main" java.lang.IllegalArgumentException: gnu.testlet.javax.imageio.spi.ServiceRegistry.registerServiceProvider$SomeService is not an ImageIO SPI class
 	-->


### PR DESCRIPTION
Disable failing gnu.testlet.java.text.MessageFormat.format14 and gnu.testlet.java.lang.System.arraycopy tests
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>