### PR TITLE
Update ASM 5.2 to 7.0 to support JDK11+

### DIFF
--- a/openjdk.build/include/top.xml
+++ b/openjdk.build/include/top.xml
@@ -141,11 +141,8 @@ limitations under the License.
 	<path id="tools.class.path">
 		<pathelement location="${prereqs_root}/tools/tools.jar"/>
 	</path>
-	<path id="asm.5.2.class.path">
-		<pathelement location="${prereqs_root}/asm-5.2/lib/asm-5.2.jar"/>
-	</path>
-	<path id="asm.6.0_BETA.class.path">
-		<pathelement location="${prereqs_root}/asm-6.0_BETA/lib/asm-6.0_BETA.jar"/>
+	<path id="asm.7.0.class.path">
+		<pathelement location="${prereqs_root}/asm-7.0/asm-7.0.jar"/>
 	</path>
 	<path id="stf.class.path">
 		<pathelement location="${stf_root}/stf.core/bin/stf.core.jar"/>
@@ -159,8 +156,7 @@ limitations under the License.
 	<target name="check-prereqs" depends="check-for-junit-4.12, print-junit-4.12-location, print-junit-4.12-error,
 										  check-for-hamcrest-core-1.3, print-hamcrest-core-1.3-location, print-hamcrest-core-1.3-error,
 										  check-for-log4j-2.3, print-log4j-2.3-location, print-log4j-2.3-error,
-										  check-for-asm-5.2, print-asm-5.2-location, print-asm-5.2-error,
-										  check-for-asm-6.0_BETA, print-asm-6.0_BETA-location, print-asm-6.0_BETA-error,
+										  check-for-asm-7.0, print-asm-7.0-location, print-asm-7.0-error,
 										  check-for-tools-jar, print-tools-jar-location, print-tools-jar-error,
 										  fail-if-error,
 										  setup-java-properties, setup-windows-compiler">
@@ -178,8 +174,7 @@ limitations under the License.
 									  check-for-junit-4.12, configure-junit-4.12, print-junit-4.12-location, print-junit-4.12-error,
 									  check-for-hamcrest-core-1.3, configure-hamcrest-core-1.3, print-hamcrest-core-1.3-location, print-hamcrest-core-1.3-error,
 									  check-for-log4j-2.3, configure-log4j-2.3, print-log4j-2.3-location, print-log4j-2.3-error,
-									  check-for-asm-5.2, configure-asm-5.2, print-asm-5.2-location, print-asm-5.2-error,
-									  check-for-asm-6.0_BETA, configure-asm-6.0_BETA, print-asm-6.0_BETA-location, print-asm-6.0_BETA-error,
+									  check-for-asm-7.0, configure-asm-7.0, print-asm-7.0-location, print-asm-7.0-error,
 									  check-for-tools-jar, configure-tools-jar, print-tools-jar-location, print-tools-jar-error,
 									  run-mauve-configure,
 									  fail-if-error">
@@ -306,40 +301,20 @@ limitations under the License.
 		<available file="${tools_jar_dir}/${tools_jar_file}" property="tools_jar_correct"/>
 	</target>
 
-	<!-- Target to check if there is an asm-5.2.jar already copied to PREREQS_ROOT/asm-5.2 -->
-	<target name="check-for-asm-5.2">
-		<property name="asm_5.2_dir" location="${prereqs_root}/asm-5.2/lib"/>
-		<property name="asm_5.2_file" value="asm-5.2.jar"/>
-		<property name="asm_5.2" value="${asm_5.2_dir}/${asm_5.2_file}"/>
-		<available file="${asm_5.2_dir}/${asm_5.2_file}" property="asm_5.2_available"/>
+	<!-- Target to check if there is an asm-7.0.jar already copied to PREREQS_ROOT/asm-7.0 -->
+	<target name="check-for-asm-7.0">
+		<property name="asm_7.0_dir" location="${prereqs_root}/asm-7.0"/>
+		<property name="asm_7.0_file" value="asm-7.0.jar"/>
+		<property name="asm_7.0" value="${asm_7.0_dir}/${asm_7.0_file}"/>
+		<available file="${asm_7.0_dir}/${asm_7.0_file}" property="asm_7.0_available"/>
 	</target>
 
-	<target name="configure-asm-5.2" unless="asm_5.2_available">
-		<!-- Fetch asm from https://download.forge.ow2.org/asm/asm-5.2-bin.zip. -->
-		<download-file destdir="${java.io.tmpdir}/asm-5.2-bin" destfile="asm-5.2-bin.zip" srcurl="https://download.forge.ow2.org/asm/asm-5.2-bin.zip"/>
-		<delete dir="${prereqs_root}/asm-5.2" failonerror="false"/>
-		<unzip src="${java.io.tmpdir}/asm-5.2-bin/asm-5.2-bin.zip" dest="${prereqs_root}"/>
-		<delete dir="${java.io.tmpdir}/asm-5.2-bin"/>
-		<property name="asm_5.2" value="${asm_5.2_dir}/${asm_5.2_file}"/>
-		<available file="${asm_5.2}" property="asm_5.2_available"/>
-	</target>
-
-	<!-- Target to check if there is an asm-6.0_BETA.jar already copied to PREREQS_ROOT/asm-6.0_BETA -->
-	<target name="check-for-asm-6.0_BETA">
-		<property name="asm_6.0_BETA_dir" location="${prereqs_root}/asm-6.0_BETA/lib"/>
-		<property name="asm_6.0_BETA_file" value="asm-6.0_BETA.jar"/>
-		<property name="asm_6.0_BETA" value="${asm_6.0_BETA_dir}/${asm_6.0_BETA_file}"/>
-	    <available file="${asm_6.0_BETA_dir}/${asm_6.0_BETA_file}" property="asm_6.0_BETA_available"/>
-	</target>
-
-	<target name="configure-asm-6.0_BETA" unless="asm_6.0_BETA_available">
-		<!-- Fetch asm from https://download.forge.ow2.org/asm/asm-6.0_BETA-bin.zip -->
-		<download-file destdir="${java.io.tmpdir}/asm-6.0_BETA-bin" destfile="asm-6.0_BETA-bin.zip" srcurl="https://download.forge.ow2.org/asm/asm-6.0_BETA-bin.zip"/>
-		<delete dir="${prereqs_root}/asm-6.0_BETA" failonerror="false"/>
-		<unzip src="${java.io.tmpdir}/asm-6.0_BETA-bin/asm-6.0_BETA-bin.zip" dest="${prereqs_root}"/>
-		<delete dir="${java.io.tmpdir}/asm-6.0_BETA-bin"/>
-		<property name="asm_6.0_BETA" value="${asm_6.0_BETA_dir}/${asm_6.0_BETA_file}"/>
-		<available file="${asm_6.0_BETA}" property="asm_6.0_BETA_available"/>
+	<target name="configure-asm-7.0" unless="asm_7.0_available">
+		<!-- Fetch asm from https://repository.ow2.org/etc. -->
+		<delete dir="${prereqs_root}/asm-7.0" failonerror="false"/>
+		<download-file destdir="${asm_7.0_dir}" destfile="${asm_7.0_file}" srcurl="https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm/7.0/asm-7.0.jar"/>
+		<property name="asm_7.0" value="${asm_7.0_dir}/${asm_7.0_file}"/>
+		<available file="${asm_7.0}" property="asm_7.0_available"/>
 	</target>
 	
 	<target name="check-for-download-tool" depends="check-for-wget, check-for-curl">
@@ -426,14 +401,10 @@ limitations under the License.
 		<echo message="Using tools.jar from ${tools_jar}"/>
 	</target>
 	
-	<target name="print-asm-5.2-location" if="asm_5.2_available">
-		<echo message="Using ${asm_5.2_file} from ${asm_5.2}"/>
+	<target name="print-asm-7.0-location" if="asm_7.0_available">
+		<echo message="Using ${asm_7.0_file} from ${asm_7.0}"/>
 	</target>
 	
-	<target name="print-asm-6.0_BETA-location" if="asm_6.0_BETA_available">
-		<echo message="Using ${asm_6.0_BETA_file} from ${asm_6.0_BETA}"/>
-	</target>
-
 	<target name="print-junit-4.12-error" unless="junit_4.12_available">
 		<echo message="ERROR: Cannot find junit-4.12 at ${junit_4.12}"/>
 		<property name="fail_run" value="true"/>
@@ -449,13 +420,8 @@ limitations under the License.
 		<property name="fail_run" value="true"/>
 	</target>
 	
-	<target name="print-asm-5.2-error" unless="asm_5.2_available">
-		<echo message="ERROR: Cannot find ${asm_5.2_file} at ${asm_5.2}"/>
-		<property name="fail_run" value="true"/>
-	</target>
-	
-	<target name="print-asm-6.0_BETA-error" unless="asm_6.0_BETA_available">
-		<echo message="ERROR: Cannot find ${asm_6.0_BETA_file} at ${asm_6.0_BETA}"/>
+	<target name="print-asm-7.0-error" unless="asm_7.0_available">
+		<echo message="ERROR: Cannot find ${asm_7.0_file} at ${asm_7.0}"/>
 		<property name="fail_run" value="true"/>
 	</target>
 	

--- a/openjdk.test.debugging/.classpath
+++ b/openjdk.test.debugging/.classpath
@@ -6,6 +6,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.load"/>
 	<classpathentry kind="lib" path="/systemtest_prereqs/tools/tools.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/asm-5.2/lib/asm-5.2.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/asm-7.0/asm-7.0.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.debugging/build.xml
+++ b/openjdk.test.debugging/build.xml
@@ -44,11 +44,9 @@ limitations under the License.
 	<path id="project.class.path">
 		<path refid="junit.class.path" />
 		<path refid="stf.class.path" />
-		<path refid="asm.5.2.class.path" />
+		<path refid="asm.7.0.class.path" />
 		<path refid="tools.class.path" />
 	</path>
-	<!-- <path refid="asm.5.2.class.path" /> -->
-	<!-- <path refid="asm.6.0_BETA.class.path" / -->
 
 	<!-- Projects which need to be built before this one. -->
 	<!-- dir must be set on the ant task otherwise the basedir property is not set to a new value in the subant task. -->

--- a/openjdk.test.debugging/docs/HCR_README.md
+++ b/openjdk.test.debugging/docs/HCR_README.md
@@ -26,8 +26,8 @@ If you attach this agent via the -javaagent argument, then this agent will run t
 
 Note: This agent is normally built by test.debugging's ant build file (build.xml), which does all these things automatically.
 
-- Step 1: Javac the following classes, in the following order, with the ASM asm-5.x.jar on the classpath.
-(Note: see section 5 for where you can get that jar. Should be version 5 or later.)
+- Step 1: Javac the following classes, in the following order, with the ASM asm-7.x.jar on the classpath.
+(Note: see section 5 for where you can get that jar. Should be version 7 or later.)
 AgentLogger.java
 MyMethodVisitor.java
 MyClassVisitor.java

--- a/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/stf/hcrAgent/HCRLateAttachWorkload.java
+++ b/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/stf/hcrAgent/HCRLateAttachWorkload.java
@@ -57,9 +57,7 @@ public class HCRLateAttachWorkload implements StfPluginInterface {
 		}
 		
 		// Specify the Process definition for the workload processes.
-		// Change the commented out line to use asm 6.0 BETA rather than asm 5.2.
-		//FileRef asmJar = test.env().findPrereqFile("/asm-6.0_BETA/lib/asm-6.0_BETA.jar");
-		FileRef asmJar = test.env().findPrereqFile("/asm-5.2/lib/asm-5.2.jar");
+		FileRef asmJar = test.env().findPrereqFile("/asm-7.0/asm-7.0.jar");
 		// Temporarily switched from using mini-mix to avoid test failures not related to HCR.
 		//String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		String inventoryFile = "/openjdk.test.load/config/inventories/util/util.xml";

--- a/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyClassVisitor.java
+++ b/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyClassVisitor.java
@@ -42,7 +42,7 @@ public class MyClassVisitor extends ClassVisitor {
 	 * @param  percentage The average percentage of public methods we want to transform.
 	 */
 	public MyClassVisitor(ClassVisitor cv, int percentage, long seed, int threadNumber) {
-		super(Opcodes.ASM5, cv);
+		super(Opcodes.ASM7, cv);
 		this.percentage = percentage;
 		randomNumberGenerator = new Random(seed);
 		this.threadNumber = threadNumber;

--- a/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyMethodVisitor.java
+++ b/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyMethodVisitor.java
@@ -36,7 +36,7 @@ public class MyMethodVisitor extends MethodVisitor {
 	 * @param threadNumber Used to generate thread-specific log messages, as many of these may be running at once.
 	 */
 	public MyMethodVisitor(MethodVisitor mv, String methodName, int randomNumber, int threadNumber) {
-		super(Opcodes.ASM5, mv);
+		super(Opcodes.ASM7, mv);
 		methodNameLocal = methodName;
 		this.randomNumber = randomNumber;
 		this.threadNumber = threadNumber;


### PR DESCRIPTION
The HCRLateAttachWorkload test won't run on JDK11 if we're not using
ASM 7.0 or up.

This change updates the version of ASM from 5.2 to 7, and also removes
the 6-beta option, as 7 supersedes both.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>