### PR TITLE
Add -Xmx256m to JLM test processes, decrease thread limit in server load

### DIFF
--- a/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmGCMXBeanNotifier.java
+++ b/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmGCMXBeanNotifier.java
@@ -61,6 +61,7 @@ public class TestJlmGCMXBeanNotifier implements StfPluginInterface {
 		// Process definition for the monitored server JVM 
 		String inventoryFile = "/test.load/config/inventories/mix/mini-mix.xml";
 		LoadTestProcessDefinition serverJavaInvocation = test.createLoadTestSpecification()
+			.addJvmOption("-Xmx256m")
 			.addJvmOption("-Dcom.sun.management.jmxremote.port=1234")
 			.addJvmOption("-Dcom.sun.management.jmxremote.authenticate=false")
 			.addJvmOption("-Dcom.sun.management.jmxremote.ssl=false")
@@ -82,6 +83,7 @@ public class TestJlmGCMXBeanNotifier implements StfPluginInterface {
 		FileRef logFile	= resultsDir.childFile("GCNotifierTest.log");
 				
 		JavaProcessDefinition client1JavaInvocation = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addProjectToClasspath("openjdk.test.jlm")
 			.addPrereqJarToClasspath(JarId.JUNIT)
 			.runClass("com.ibm.runtimes.test.remote.GarbageCollectionNotificationTest") //
@@ -108,7 +110,8 @@ public class TestJlmGCMXBeanNotifier implements StfPluginInterface {
 		
 		// Process definition for the monitoring client JVM that connects with the server			
         JavaProcessDefinition client2JavaInvocation =  test.createJavaProcessDefinition()
-		    .addProjectToClasspath("openjdk.test.jlm")
+        	.addJvmOption("-Xmx256m")
+        	.addProjectToClasspath("openjdk.test.jlm")
 			.addPrereqJarToClasspath(JarId.JUNIT)
 			.runClass("com.ibm.runtimes.test.remote.GCMXBeanTest");
 		

--- a/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteClassAuth.java
+++ b/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteClassAuth.java
@@ -76,6 +76,7 @@ public class TestJlmRemoteClassAuth implements StfPluginInterface {
 		String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		
 		LoadTestProcessDefinition serverLoadTestInvocation = test.createLoadTestSpecification()
+			.addJvmOption("-Xmx256m")
 			.addJvmOption("-Dcom.sun.management.jmxremote.port=1234")
 			.addJvmOption("-Dcom.sun.management.jmxremote.ssl.need.client.auth=true")
 			.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
@@ -95,7 +96,7 @@ public class TestJlmRemoteClassAuth implements StfPluginInterface {
 			.addSuite("mini-mix")
 			.setSuiteNumTests(900000)
 			.setSuiteInventory(inventoryFile)
-			.setSuiteThreadCount(200)
+			.setSuiteThreadCount(30)
 		   	.setSuiteRandomSelection();
 		
 		// Process definition for the client JVM that will monitor the server using proxy connection
@@ -105,6 +106,7 @@ public class TestJlmRemoteClassAuth implements StfPluginInterface {
 		FileRef dumpFile = resultsDir.childFile("javacore_scls_proxy.%Y%m%d.%H%M%S.%pid.%seq.txt,filter=java.lang.IllegalArgumentException");
 		
 		JavaProcessDefinition clientJavaInvocationProxy =  test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 	 		.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.trustStore=" + keyStoreFile.getSpec())
@@ -134,7 +136,7 @@ public class TestJlmRemoteClassAuth implements StfPluginInterface {
 		StfProcess clientProxy = test.doRunBackgroundProcess("Running Monitoring "
 				+ "Client with proxy connection(with security)", 
 				"CL1", ECHO_ON,  
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocationProxy);
 		
 		// Wait for the processes to complete
@@ -150,6 +152,7 @@ public class TestJlmRemoteClassAuth implements StfPluginInterface {
 		statsFile = resultsDir.childFile("scls_server.csv");
 		dumpFile = resultsDir.childFile("javacore_scls_server.%Y%m%d.%H%M%S.%pid.%seq.txt,filter=java.lang.IllegalArgumentException");
 		JavaProcessDefinition clientJavaInvocationS = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.trustStore=" + keyStoreFile.getSpec())
@@ -177,7 +180,7 @@ public class TestJlmRemoteClassAuth implements StfPluginInterface {
 		// Start the background client process
 		StfProcess clientS = test.doRunBackgroundProcess("Run the Monitoring Client with server-connection(with security)", 
 				"CL2", ECHO_ON,  
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocationS);
 		
 		// Wait for background processes to complete 

--- a/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteClassNoAuth.java
+++ b/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteClassNoAuth.java
@@ -68,6 +68,7 @@ public class TestJlmRemoteClassNoAuth implements StfPluginInterface {
 		String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		
 		LoadTestProcessDefinition serverLoadTestInvocation = test.createLoadTestSpecification()
+			.addJvmOption("-Xmx256m")
 			.addJvmOption("-Dcom.sun.management.jmxremote.port=1234")
 			.addJvmOption("-Dcom.sun.management.jmxremote.authenticate=false")
 			.addJvmOption("-Dcom.sun.management.jmxremote.ssl=false")
@@ -81,11 +82,12 @@ public class TestJlmRemoteClassNoAuth implements StfPluginInterface {
 			.addSuite("mini-mix")
 			.setSuiteNumTests(900000)
 			.setSuiteInventory(inventoryFile)
-			.setSuiteThreadCount(200)
+			.setSuiteThreadCount(30)
 		   	.setSuiteRandomSelection();
 		
 		// Process definition for the client JVM using proxy connection
 		JavaProcessDefinition clientJavaInvocationProxy = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 		 	.addProjectToClasspath("openjdk.test.jlm")
 			.addPrereqJarToClasspath(JarId.JUNIT)
@@ -99,6 +101,7 @@ public class TestJlmRemoteClassNoAuth implements StfPluginInterface {
 
 		// Process definition for the client JVM using server connection
 		JavaProcessDefinition clientJavaInvocationServer = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 	 		.addProjectToClasspath("openjdk.test.jlm")
 			.addPrereqJarToClasspath(JarId.JUNIT)
@@ -119,7 +122,7 @@ public class TestJlmRemoteClassNoAuth implements StfPluginInterface {
 		StfProcess clientProxy = test.doRunBackgroundProcess("Running the monitoring "
 				+ "Client with proxy connection(without security)", 
 				"CL1", ECHO_ON,  
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocationProxy);
 		
 		// Wait for the processes to complete
@@ -142,7 +145,7 @@ public class TestJlmRemoteClassNoAuth implements StfPluginInterface {
 		StfProcess clientS = test.doRunBackgroundProcess("Running the Monitoring "
 				+ "Client with server-connection(without security)", 
 				"CL2", ECHO_ON,
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocationServer);
 		
 		// Wait for processes to complete

--- a/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteMemoryAuth.java
+++ b/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteMemoryAuth.java
@@ -76,6 +76,7 @@ public class TestJlmRemoteMemoryAuth implements StfPluginInterface {
 		String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		
 		LoadTestProcessDefinition serverLoadTestInvocation = test.createLoadTestSpecification()
+			.addJvmOption("-Xmx256m")
 			.addJvmOption("-Dcom.sun.management.jmxremote.port=1234")
 			.addJvmOption("-Dcom.sun.management.jmxremote.ssl.need.client.auth=true")
 			.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
@@ -95,7 +96,7 @@ public class TestJlmRemoteMemoryAuth implements StfPluginInterface {
 			.addSuite("mini-mix")
 			.setSuiteNumTests(900000)
 			.setSuiteInventory(inventoryFile)
-			.setSuiteThreadCount(200)
+			.setSuiteThreadCount(30)
 		   	.setSuiteRandomSelection();
 
 		// Process definition for the client JVM that will monitor the server using proxy connection
@@ -105,6 +106,7 @@ public class TestJlmRemoteMemoryAuth implements StfPluginInterface {
 		FileRef dumpFile = resultsDir.childFile("javacore_smem_proxy.%Y%m%d.%H%M%S.%pid.%seq.txt,filter=java.lang.IllegalArgumentException");
 		
 		JavaProcessDefinition clientJavaInvocationProxy = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.trustStore=" + keyStoreFile.getSpec())
@@ -149,6 +151,7 @@ public class TestJlmRemoteMemoryAuth implements StfPluginInterface {
 		dumpFile = resultsDir.childFile("javacore_smem_server.%Y%m%d.%H%M%S.%pid.%seq.txt,filter=java.lang.IllegalArgumentException");
 		
 		JavaProcessDefinition clientJavaInvocationS = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.trustStore=" + keyStoreFile.getSpec())

--- a/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteMemoryNoAuth.java
+++ b/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteMemoryNoAuth.java
@@ -63,6 +63,7 @@ public class TestJlmRemoteMemoryNoAuth implements StfPluginInterface {
 		String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		
 		LoadTestProcessDefinition serverJavaInvocation = test.createLoadTestSpecification()
+			.addJvmOption("-Xmx256m")
 			.addJvmOption("-Dcom.sun.management.jmxremote.port=1234")
 			.addJvmOption("-Dcom.sun.management.jmxremote.authenticate=false")
 			.addJvmOption("-Dcom.sun.management.jmxremote.ssl=false")
@@ -76,7 +77,7 @@ public class TestJlmRemoteMemoryNoAuth implements StfPluginInterface {
 			.addSuite("mini-mix")
 			.setSuiteNumTests(900000)
 			.setSuiteInventory(inventoryFile)
-			.setSuiteThreadCount(200)
+			.setSuiteThreadCount(30)
 		   	.setSuiteRandomSelection();
 		
 		// Process definition for the monitoring client JVM that connects with the server via proxy	
@@ -86,6 +87,7 @@ public class TestJlmRemoteMemoryNoAuth implements StfPluginInterface {
 		FileRef dumpFile = resultsDir.childFile("javacore_mem_proxy.%Y%m%d.%H%M%S.%pid.%seq.txt,filter=java.lang.IllegalArgumentException");
 				
 		JavaProcessDefinition clientJavaInvocationProxy = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addProjectToClasspath("openjdk.test.jlm")
 			.addPrereqJarToClasspath(JarId.JUNIT)
@@ -121,7 +123,8 @@ public class TestJlmRemoteMemoryNoAuth implements StfPluginInterface {
 		dumpFile = resultsDir.childFile("javacore_mem_server.%Y%m%d.%H%M%S.%pid.%seq.txt,filter=java.lang.IllegalArgumentException");
 		
         JavaProcessDefinition clientJavaInvocationServer =  test.createJavaProcessDefinition()
-		    .addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
+        	.addJvmOption("-Xmx256m")
+        	.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addProjectToClasspath("openjdk.test.jlm")
 			.addPrereqJarToClasspath(JarId.JUNIT)
 			.runClass(MemoryProfiler.class)

--- a/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteNotifierProxyAuth.java
+++ b/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteNotifierProxyAuth.java
@@ -73,6 +73,7 @@ public class TestJlmRemoteNotifierProxyAuth implements StfPluginInterface {
 		String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		
 		LoadTestProcessDefinition serverJavaInvocation = test.createLoadTestSpecification()
+				.addJvmOption("-Xmx256m")
 				.addJvmOption("-Dcom.sun.management.jmxremote.port=1234")
 				.addJvmOption("-Dcom.sun.management.jmxremote.ssl.need.client.auth=true")
 				.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
@@ -92,11 +93,12 @@ public class TestJlmRemoteNotifierProxyAuth implements StfPluginInterface {
 				.addSuite("mini-mix")
 				.setSuiteNumTests(900000)
 				.setSuiteInventory(inventoryFile)
-				.setSuiteThreadCount(200)
+				.setSuiteThreadCount(30)
 			   	.setSuiteRandomSelection();
 		
 		// Process definition for the client JVM that will monitor the server
 		JavaProcessDefinition clientJavaInvocation = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.trustStore=" + keyStoreFile.getSpec())
@@ -124,7 +126,7 @@ public class TestJlmRemoteNotifierProxyAuth implements StfPluginInterface {
 		// Start the background client process
 		StfProcess client = test.doRunBackgroundProcess("Run client with proxy JMX connection with security", 
 				"CL", ECHO_ON,  
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocation);
 		
 		// Wait for the processes to complete

--- a/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteThreadAuth.java
+++ b/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteThreadAuth.java
@@ -76,6 +76,7 @@ public class TestJlmRemoteThreadAuth implements StfPluginInterface {
 		String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		
 		LoadTestProcessDefinition serverLoadTestInvocation = test.createLoadTestSpecification()
+				.addJvmOption("-Xmx256m")
 				.addJvmOption("-Dcom.sun.management.jmxremote.port=1234")
 				.addJvmOption("-Dcom.sun.management.jmxremote.ssl.need.client.auth=true")
 				.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
@@ -95,7 +96,7 @@ public class TestJlmRemoteThreadAuth implements StfPluginInterface {
 				.addSuite("mini-mix")
 				.setSuiteNumTests(900000)
 				.setSuiteInventory(inventoryFile)
-				.setSuiteThreadCount(200)
+				.setSuiteThreadCount(30)
 			   	.setSuiteRandomSelection();
 		
 		// Process definition for the client JVM that will monitor the server using proxy connection
@@ -105,6 +106,7 @@ public class TestJlmRemoteThreadAuth implements StfPluginInterface {
 		FileRef dumpFile = resultsDir.childFile("javacore_sthd_proxy.%Y%m%d.%H%M%S.%pid.%seq.txt,filter=java.lang.IllegalArgumentException");
 		
 		JavaProcessDefinition clientJavaInvocationProxy =  test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.trustStore=" + keyStoreFile.getSpec())
@@ -134,7 +136,7 @@ public class TestJlmRemoteThreadAuth implements StfPluginInterface {
 		StfProcess clientProxy = test.doRunBackgroundProcess("Running Monitoring "
 				+ "Client with proxy connection(with security)", 
 				"CL1", ECHO_ON,  
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocationProxy);
 		
 		// Wait for the processes to complete
@@ -150,6 +152,7 @@ public class TestJlmRemoteThreadAuth implements StfPluginInterface {
 		statsFile = resultsDir.childFile("sthd_server.csv");
 		dumpFile = resultsDir.childFile("javacore_sthd_server.%Y%m%d.%H%M%S.%pid.%seq.txt,filter=java.lang.IllegalArgumentException");
 		JavaProcessDefinition clientJavaInvocationS = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.keyStore=" + keyStoreFile.getSpec())
 			.addJvmOption("-Djavax.net.ssl.trustStore=" + keyStoreFile.getSpec())
@@ -177,7 +180,7 @@ public class TestJlmRemoteThreadAuth implements StfPluginInterface {
 		// Start the background client process
 		StfProcess clientS = test.doRunBackgroundProcess("Run the Monitoring Client with server-connection(with security)", 
 				"CL2", ECHO_ON,  
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocationS);
 		
 		// Wait for background processes to complete

--- a/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteThreadNoAuth.java
+++ b/openjdk.test.jlm/src/test.jlm/net/adoptopenjdk/test/jlm/TestJlmRemoteThreadNoAuth.java
@@ -68,6 +68,7 @@ public class TestJlmRemoteThreadNoAuth implements StfPluginInterface {
 		String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		
 		LoadTestProcessDefinition serverLoadTestInvocation = test.createLoadTestSpecification()
+			.addJvmOption("-Xmx256m")
 			.addJvmOption("-Dcom.sun.management.jmxremote.port=1234")
 			.addJvmOption("-Dcom.sun.management.jmxremote.authenticate=false")
 			.addJvmOption("-Dcom.sun.management.jmxremote.ssl=false")
@@ -81,11 +82,12 @@ public class TestJlmRemoteThreadNoAuth implements StfPluginInterface {
 			.addSuite("mini-mix")
 			.setSuiteNumTests(900000)
 			.setSuiteInventory(inventoryFile)
-			.setSuiteThreadCount(200)
+			.setSuiteThreadCount(30)
 		   	.setSuiteRandomSelection();
 		
 		// Process definition for the client JVM using proxy connection	
 		JavaProcessDefinition clientJavaInvocationProxy = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addProjectToClasspath("openjdk.test.jlm")
 			.addPrereqJarToClasspath(JarId.JUNIT)
@@ -99,6 +101,7 @@ public class TestJlmRemoteThreadNoAuth implements StfPluginInterface {
 
 		// Process definition for the client JVM using server connection
 		JavaProcessDefinition clientJavaInvocationServer = test.createJavaProcessDefinition()
+			.addJvmOption("-Xmx256m")
 			.addJvmOptionIfIBMJava("-Xdump:java:events=throw,file=" + dumpFile.getSpec())
 			.addProjectToClasspath("openjdk.test.jlm")
 			.addPrereqJarToClasspath(JarId.JUNIT)
@@ -119,7 +122,7 @@ public class TestJlmRemoteThreadNoAuth implements StfPluginInterface {
 		StfProcess clientProxy = test.doRunBackgroundProcess("Running the monitoring "
 				+ "Client with proxy connection(without security)", 
 				"CL1", ECHO_ON,  
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocationProxy);
 		
 		// Wait for the processes to complete
@@ -142,7 +145,7 @@ public class TestJlmRemoteThreadNoAuth implements StfPluginInterface {
 		StfProcess clientS = test.doRunBackgroundProcess("Running the Monitoring "
 				+ "Client with server-connection(without security)", 
 				"CL2", ECHO_ON,
-				ExpectedOutcome.cleanRun().within("10m"), 
+				ExpectedOutcome.cleanRun().within("30m"), 
 				clientJavaInvocationServer);
 		
 		// Wait for processes to complete


### PR DESCRIPTION
resolves https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/249
igned-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>