### PR TITLE
Permanently exclude testlet.javax.net.ssl.SSLContext.TestDefaultInit

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -1,4 +1,8 @@
 <inventory>
+	<!-- Fails on jdk12 openj9 on ppcle linux with: 
+		 java.security.AccessControlException: access denied: ("java.util.logging.LoggingPermission" "control")
+		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/263-->
+	<mauve class="gnu.testlet.javax.net.ssl.SSLContext.TestDefaultInit"/>
 	<!-- Fails on jdk12 aarch64 linux hotspot with: 
 		 got -4616189728938546314 but expected -4616189728938546315
 		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/256-->

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -1,4 +1,8 @@
 <inventory>
+	<!-- Fails on jdk12 openj9 on ppcle linux with: 
+		java.security.AccessControlException: access denied: ("java.util.logging.LoggingPermission" "control")
+		Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/263-->
+	<mauve class="gnu.testlet.javax.net.ssl.SSLContext.TestDefaultInit"/> 
 	<!-- Fails on jdk11 and jdk12 openj9 with: 
 	java.net.SocketException: maximum number of DatagramSockets reached binding to null address (number 0) 
 	Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/237-->


### PR DESCRIPTION
Related to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/263
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>