### PR TITLE
Permanently exclude Handler.isLoggable as it fails on jdk13

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -1,4 +1,8 @@
 <inventory>
+	<!-- Fails on jdk13 openj9 with: 
+		 FAIL: gnu.testlet.java.util.logging.Handler.isLoggable (number 0)
+		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/260-->
+	<mauve class="gnu.testlet.java.util.logging.Handler.isLoggable"/>
 	<!-- Fails on jdk11 openj9 on s390 linux with: 
 		 FAIL: gnu.testlet.java.util.zip.ZipEntry.time: setTime or getTime broken (number 0)
 			   got 1086325228000 but expected 1086310828000

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -1,6 +1,9 @@
 <inventory>
-
-<!-- Fails on jdk11 openj9 on s390 linux with: 
+	<!-- Fails on jdk13 openj9 with: 
+		 FAIL: gnu.testlet.java.util.logging.Handler.isLoggable (number 0)
+		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/260-->
+	<mauve class="gnu.testlet.java.util.logging.Handler.isLoggable"/>
+	<!-- Fails on jdk11 openj9 on s390 linux with: 
 		 FAIL: gnu.testlet.java.util.zip.ZipEntry.time: setTime or getTime broken (number 0)
 			   got 1086325228000 but expected 1086310828000
 		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/267-->


### PR DESCRIPTION
Resolves https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/260
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>