### PR TITLE
Increase Mauve Multithreaded load test timeout

### DIFF
--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveMultiThreadLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveMultiThreadLoadTest.java
@@ -75,7 +75,7 @@ public class MauveMultiThreadLoadTest implements StfPluginInterface {
 				.setSuiteRandomSelection();
 		
 		test.doRunForegroundProcess("Run Mauve load test", "LT", Echo.ECHO_ON,
-				ExpectedOutcome.cleanRun().within("1h"), 
+				ExpectedOutcome.cleanRun().within("2h"), 
 				loadTestInvocation);
 	}
 


### PR DESCRIPTION
We need to increase timeout of this test especially for Windows runs with special modes (e.g. Mode610-OSRG) where it takes longer than usual time to complete. 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>