### PR TITLE
WIP: Exclude multithreaded mauve sub-tests that reference SecurityManager

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -9,6 +9,8 @@
 	<mauve class="gnu.testlet.java.net.URLConnection.getPermission"/>
 	<mauve class="gnu.testlet.java.net.URLStreamHandler.Except"/>
 	<mauve class="gnu.testlet.java.net.HttpURLConnection.responseHeadersTest"/>
+	<mauve class="gnu.testlet.javax.security.auth.login.TestOfPR25202"/>
+	<mauve class="gnu.testlet.java.lang.reflect.Proxy.check13"/>
 	
 	<!-- Fails on jdk12 hotspot with: 
 		 got 9218868437227405313 but expected 9223231299366420480


### PR DESCRIPTION
Related to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/284 
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>