### PR TITLE
Resurrect mauve sub-test excludes for SecurityManager issues

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -12,10 +12,6 @@
 			   got 1086325228000 but expected 1086310828000
 		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/267-->
 	<mauve class="gnu.testlet.java.util.zip.ZipEntry.time"/>
-	<!-- Fails on jdk12 openj9 on ppcle linux with: 
-		 java.security.AccessControlException: access denied: ("java.util.logging.LoggingPermission" "control")
-		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/263-->
-	<mauve class="gnu.testlet.javax.net.ssl.SSLContext.TestDefaultInit"/>
 	<!-- Fails on jdk12 aarch64 linux hotspot with: 
 		 got -4616189728938546314 but expected -4616189728938546315
 		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/256-->

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -1,15 +1,8 @@
 <inventory>
-	<!-- 
-	Tests that use SecurityManager fail intermittently when run in a 
-	multi-threaded environment due to timing issues. 
-	Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/271
-	 -->
-	<mauve class="gnu.testlet.java.security.ProtectionDomain.Implies"/>
-	<mauve class="gnu.testlet.java.net.URLConnection.getRequestProperties"/>
-	<mauve class="gnu.testlet.java.net.URLConnection.getPermission"/>
-	<mauve class="gnu.testlet.java.net.URLStreamHandler.Except"/>
-	<mauve class="gnu.testlet.java.net.HttpURLConnection.responseHeadersTest"/>
-	
+	<!-- Exclude tests that install SecurityManager 
+	Issue Ref: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/284-->
+	<mauve class="gnu.testlet.java.util.logging.Logger.getAnonymousLogger"/>
+	<mauve class="gnu.testlet.java.util.logging.Logger.getName"/>
 	<!-- Fails on jdk12 hotspot with: 
 		 got 9218868437227405313 but expected 9223231299366420480
 		 Issue reference: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/272-->


### PR DESCRIPTION
Related to : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/284

Ref: https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/284#issuecomment-527588341

Background: We were previously excluding all mauve sub-tests where we were seeing AccessControlException for security manager. This was the a wrong approach. What we need is to identify the sub-tests that install SecurityManager and exclude them. 

The way we have since identified the tests that install a SecurityManager is 

- Run grinders for multi-threaded mauve tests with following extra option: 
`-Xtrace:iprint=mt,trigger=method{java/lang/System.setSecurityManager*,jstacktrace} `
- Search for `.install` and exclude the sub-test that installs security manager. 

This PR un-excludes the previously excluded sub-tests, and excludes the 2 tests that actually do install Security Manager. 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>