### PR TITLE
Remove obsoleted modules for JDK11+

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -333,8 +333,9 @@ public class Jck implements StfPluginInterface {
 			if ( (testSuite == TestSuite.RUNTIME) && (tests.contains("api/java_util") || tests.contains("api/java_net") || tests.contains("api/java_rmi")  || tests.contains("api/javax_management") 
 					|| tests.contains("api/org_omg") || tests.contains("api/javax_xml") || tests.equals("api") || tests.contains("vm/jdwp") || tests.equals("vm")) ) {
 				String addModules = "";
-				// Post Java 8 the javatest agent needs to be given access to non default modules.
-				if ( ! jckVersion.contains("jck8") ) {
+				// JCK 9/10 javatest agents need to be given access to non default modules.
+				// JCK 8 doesn't support modules, JCK11 and beyond have removed these two modules: java.xml.ws,java.corba.
+				if ( jckVersion.contains("jck9") || jckVersion.contains("jck10") ) {
 					addModules = "--add-modules java.xml.ws,java.corba";
 				}
 				javatestAgent = test.doRunBackgroundProcess("Starting javatest agent", "AGNT", ECHO_ON, ExpectedOutcome.neverCompletes(), test.createJavaProcessDefinition()


### PR DESCRIPTION
**Remove obsoleted modules for JDK11+**

Modules `java.xml.ws` & `java.corba` have been removed from `JDK11+`.
Only add them for `JCK 9/10`.
`JDK8` doesn't support modules.

`--add-modules java.xml.ws,java.corba` can't be added for `JDK11+`, otherwise `javatest agent` can't start with following exception hence the `test harness` just failed with `Error accessing agent: java.net.ConnectException: Connection refused (Connection refused)`.
```
java.lang.module.FindException: Module java.xml.ws not found
        at java.base/java.lang.module.Resolver.findFail(Resolver.java:877)
        at java.base/java.lang.module.Resolver.resolve(Resolver.java:128)
        at java.base/java.lang.module.Configuration.resolveAndBind(Configuration.java:304)
```

Verified in a local run that `JDK11` passed JCK sub-test `vm/jdwp`.

Reviewer: @smlambert 
FYI: @DanHeidinga @pshipton

Signed-off-by: Jason Feng <fengj@ca.ibm.com>