### PR TITLE
Add support for BSD/amd64

### DIFF
--- a/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
+++ b/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
@@ -52,7 +52,7 @@ P=:
 ###
 # Check platform is set to a single valid value
 ###
-VALID_PLATFORMS?=osx_x86-64,aix_ppc-32,aix_ppc-64,linux_390-31,linux_390-64,linux_ppc-32,linux_ppc-64,linux_x86-32,linux_x86-64,win_x86-32,win_x86-64,zos_390-31,zos_390-64,linux_ppcle-64,linux_arm-32,linux_arm-64
+VALID_PLATFORMS?=osx_x86-64,aix_ppc-32,aix_ppc-64,linux_390-31,linux_390-64,linux_ppc-32,linux_ppc-64,linux_x86-32,linux_x86-64,win_x86-32,win_x86-64,zos_390-31,zos_390-64,linux_ppcle-64,linux_arm-32,linux_arm-64,bsd_x86-64
 ifndef PLATFORM
   $(error "The variable PLATFORM needs to be defined")
 endif
@@ -126,6 +126,14 @@ ifeq ($(PLATFORM),win_x86-64)
     WIN=1
 endif
  
+ifeq ($(PLATFORM),bsd_x86-64)
+	CC=cc
+	LD=cc
+	IFLAGS=-I. -I$(HEADERDIR) -I$(JAVA_HOME)/include/$(shell uname | tr "[:upper:]" "[:lower:]") -I$(JAVA_HOME)/include -I/usr/include
+	CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -m64 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
+	LFLAGS=-shared -m64 -o
+endif
+
 ifeq ($(WIN),1)
 
     # Environment variable OSTYPE is set to cygwin if running under cygwin.


### PR DESCRIPTION
* Recognise bsd_x86-64 as a valid platform
* Set up make variables to work on bsd_x86-64
  * FreeBSD and OpenBSD have both switched to Clang as default and don't have gcc
  * NetBSD, I believe, still has gcc as default, but 'cc' will still work
  * The include file path jni_md.h uses the full OS name, e.g. 'freebsd', rather than just 'bsd'.
  * Other setup mirrors Linux for the most part

Note that other architectures are possible here (e.g., bsd_x86-32), but are not included in this change.