### PR TITLE
Revert "Use encoding ISO-8859-1 for compiling system tests"

### DIFF
--- a/openjdk.test.classloading/build.xml
+++ b/openjdk.test.classloading/build.xml
@@ -94,7 +94,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />
@@ -113,7 +113,7 @@ limitations under the License.
 					   executable="${java_compiler}"
 					   debug="true"
 					   classpath="${openjdk_test_classloading_src_dir}/notonclasspath/url2"
-					   encoding="ISO-8859-1"
+			           encoding="${src-encoding}"
 					   includeantruntime="false"
 					   failonerror="true">
 					   <compilerarg value="-Xlint:deprecation,unchecked" />
@@ -125,7 +125,7 @@ limitations under the License.
 					   executable="${java_compiler}"
 					   debug="true"
 					   classpath="${openjdk_test_classloading_src_dir}/notonclasspath/url1"
-					   encoding="ISO-8859-1"
+					   encoding="${src-encoding}"
 					   includeantruntime="false"
 					   failonerror="true">
 					   <compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openjdk.test.concurrent/build.xml
+++ b/openjdk.test.concurrent/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openjdk.test.debugging/build.xml
+++ b/openjdk.test.debugging/build.xml
@@ -110,7 +110,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openjdk.test.gc/build.xml
+++ b/openjdk.test.gc/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openjdk.test.jck/build.xml
+++ b/openjdk.test.jck/build.xml
@@ -96,7 +96,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openjdk.test.jlm/build.xml
+++ b/openjdk.test.jlm/build.xml
@@ -84,7 +84,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openjdk.test.lambdasAndStreams/build.xml
+++ b/openjdk.test.lambdasAndStreams/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openjdk.test.lang/build.xml
+++ b/openjdk.test.lang/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openjdk.test.load/build.xml
+++ b/openjdk.test.load/build.xml
@@ -83,7 +83,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openjdk.test.locking/build.xml
+++ b/openjdk.test.locking/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openjdk.test.math/build.xml
+++ b/openjdk.test.math/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openjdk.test.mauve/build.xml
+++ b/openjdk.test.mauve/build.xml
@@ -116,7 +116,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   classpathref="project.class.path"
 			   debug="true"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java" />
@@ -150,7 +150,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   classpathref="project.class.path"
 			   debug="true"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="*.java" />

--- a/openjdk.test.nio/build.xml
+++ b/openjdk.test.nio/build.xml
@@ -100,7 +100,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   failonerror="true">
 			<include name="net/adoptopenjdk/test/nio2/filesystem/**"/>
 		</javac>
@@ -154,7 +154,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<include name="**/*.java"/>

--- a/openjdk.test.nio/src/test.nio/net/adoptopenjdk/test/nio2/perl/filesystems/generateProviders.pl
+++ b/openjdk.test.nio/src/test.nio/net/adoptopenjdk/test/nio2/perl/filesystems/generateProviders.pl
@@ -39,11 +39,11 @@ close(TEMPLATE_FILE);
 my $numberOfProvidersToCreate = 1000;
 
 # To create the file required for the JVM to know about the SPI Providers
-open SERVICES, ">:encoding(ISO-8859-1)", $services_file or die "Unable to open services file - $services_file";
+open SERVICES, ">:encoding(UTF-8)", $services_file or die "Unable to open services file - $services_file";
 
 for (my $counter = 0; $counter < $numberOfProvidersToCreate; $counter++) {
 
-	open OUTPUT_FILE, ">:encoding(ISO-8859-1)",catfile("$Bin", "..","..","filesystem","MemoryFileSystemProviderImpl${counter}.java");
+	open OUTPUT_FILE, ">:encoding(UTF-8)",catfile("$Bin", "..","..","filesystem","MemoryFileSystemProviderImpl${counter}.java");
 
 	# Update the file contents with the right counter value	
 	my $iterationContents = $templateContents;

--- a/openjdk.test.serialization/build.xml
+++ b/openjdk.test.serialization/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />

--- a/openjdk.test.util/build.xml
+++ b/openjdk.test.util/build.xml
@@ -89,7 +89,7 @@ limitations under the License.
 			   executable="${java_compiler}"
 			   debug="true"
 			   classpathref="project.class.path"
-			   encoding="ISO-8859-1"
+			    encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
 			<compilerarg value="-Xlint:deprecation,unchecked" />


### PR DESCRIPTION
This reverts commit 65e79edbe3a365ac0b7fcecb8126ace8f6a39c28.

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>