### PR TITLE
Turn off jdwp.VMSuspended in jck8

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -688,6 +688,10 @@ public class Jck implements StfPluginInterface {
 				if (tests.contains("api/signaturetest") || tests.equals("api")) {
 					fileContent += "set jck.env.runtime.staticsigtest.staticSigTestClasspathRemote \"" + getSignatureTestJars(pathToLib) + "\"" + ";\n";
 				}
+				if (tests.contains("jdwp")) {
+					fileContent += "set jck.env.runtime.jdwp.VMSuspended No;\n";
+					fileContent += "set jck.env.runtime.jdwp.jdwpOpts -agentlib:jdwp=server=y,transport=dt_socket,address=localhost:35000,suspend=n;\n";
+				}
 			}
 			if (extraJvmOptions.contains("nofallback") && tests.startsWith("vm") ) {
 				fileContent += "set jck.env.testPlatform.typecheckerSpecific No" + ";\n";		


### PR DESCRIPTION
- Related to : https://github.ibm.com/runtimes/JCK8-unzipped/pull/5#issuecomment-15302207

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>