### PR TITLE
Disable ftpSupport temporarily

### DIFF
--- a/openjdk.test.jck/config/jck11/runtime.jti
+++ b/openjdk.test.jck/config/jck11/runtime.jti
@@ -38,7 +38,7 @@ jck.env.runtime.fp.floatMinExponent=
 jck.env.runtime.fp.format=Intel, 15 bit exponent
 jck.env.runtime.fp.supportExtended=Yes
 jck.env.runtime.fp=Yes
-jck.env.runtime.ftpSupport=Yes
+jck.env.runtime.ftpSupport=No
 # jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
 jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.idl.orbPort=9876

--- a/openjdk.test.jck/config/jck13/runtime.jti
+++ b/openjdk.test.jck/config/jck13/runtime.jti
@@ -38,7 +38,7 @@ jck.env.runtime.fp.floatMinExponent=
 jck.env.runtime.fp.format=Intel, 15 bit exponent
 jck.env.runtime.fp.supportExtended=Yes
 jck.env.runtime.fp=Yes
-jck.env.runtime.ftpSupport=Yes
+jck.env.runtime.ftpSupport=No
 # jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
 jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.idl.orbPort=9876

--- a/openjdk.test.jck/config/jck8b/compiler.jti
+++ b/openjdk.test.jck/config/jck8b/compiler.jti
@@ -101,7 +101,7 @@ jck.env.runtime.fp.doubleMinExponent=
 jck.env.runtime.fp.floatMaxExponent=
 jck.env.runtime.fp.floatMinExponent=
 jck.env.runtime.fp.supportExtended=No
-jck.env.runtime.ftpSupport=Yes
+jck.env.runtime.ftpSupport=No
 # jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
 jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.idl.orbPort=1,050

--- a/openjdk.test.jck/config/jck8b/devtools.jti
+++ b/openjdk.test.jck/config/jck8b/devtools.jti
@@ -101,7 +101,7 @@ jck.env.runtime.fp.doubleMinExponent=
 jck.env.runtime.fp.floatMaxExponent=
 jck.env.runtime.fp.floatMinExponent=
 jck.env.runtime.fp.supportExtended=No
-jck.env.runtime.ftpSupport=Yes
+jck.env.runtime.ftpSupport=No
 # jck.env.runtime.idl.orbHost example: localhost
 jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time
 jck.env.runtime.jaas.authPolicy=standard system property

--- a/openjdk.test.jck/config/jck8b/runtime.jti
+++ b/openjdk.test.jck/config/jck8b/runtime.jti
@@ -87,7 +87,7 @@ jck.env.runtime.fp.floatMaxExponent=
 jck.env.runtime.fp.floatMinExponent=
 jck.env.runtime.fp.format=Intel, 15 bit exponent
 jck.env.runtime.fp.supportExtended=Yes
-jck.env.runtime.ftpSupport=Yes
+jck.env.runtime.ftpSupport=No
 jck.env.runtime.idl=Yes
 # jck.env.runtime.idl.orbHost example: xxxx.xxxx.xxxx.com
 jck.env.runtime.idl.orbHost=will_be_set_by_test_automation_at_run_time

--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -82,7 +82,6 @@ public class Jck implements StfPluginInterface {
 	private String testHost2Name;
 	private String testHost2Ip;
 	private String httpUrl;
-	private String ftpUrl;
 	private String krb5ClientPassword;
 	private String krb5ClientUsername;
 	private String krb5ServerPassword;
@@ -255,7 +254,6 @@ public class Jck implements StfPluginInterface {
 			testHost2Name = prop.getProperty("testhost2name");
 			testHost2Ip = prop.getProperty("testhost2ip");
 			httpUrl = prop.getProperty("httpurl");
-			ftpUrl = prop.getProperty("ftpurl");
 			// Make sure username properties do not have trailing whitespace before adding server location data.
 			krb5ClientPassword = prop.getProperty("krb5ClientPassword");
 			krb5ClientUsername = prop.getProperty("krb5ClientUsername");
@@ -634,7 +632,6 @@ public class Jck implements StfPluginInterface {
 				fileContent += "set jck.env.runtime.net.testHost2IPAddr " + testHost2Ip + ";\n";
 			}
 			if ( tests.contains("api/java_net") || tests.equals("api") ) {
-				fileContent += "set jck.env.runtime.url.ftpURL " + ftpUrl + ";\n";
 				fileContent += "set jck.env.runtime.url.httpURL " + httpUrl + ";\n";
 				fileContent += "set jck.env.runtime.url.fileURL " + fileUrl + ";\n";
 			}


### PR DESCRIPTION
**Disable ftpSupport temporarily**

Aim for a green `jck.extended` build.
Should be re-enabled when ftp server is setup properly.

Current `ftp` test failures:
```
----------out1:(6/368)----------
URL2022: Failed. Unexpected exception:java.net.ConnectException: Connection timed out (Connection timed out)
URL2024: Failed. Unexpected exception:java.net.ConnectException: Connection timed out (Connection timed out)
URL2023: Passed. OKAY
URL2026: Passed. OKAY
URL2025: Passed. OKAY
STATUS:Failed.test cases: 5; passed: 3; failed: 2; first test case failure: URL2022
```

With this PR, the test suite passes with following output:
```
----------out1:(6/246)----------
URL2022: Passed. Testcase skipped since ftp protocol is not supported
URL2024: Passed. Testcase skipped since ftp protocol is not supported
URL2023: Passed. OKAY
URL2026: Passed. OKAY
URL2025: Passed. OKAY
STATUS:Passed.test cases: 5; all passed
----------out2:(0/0)----------
result: Passed. test cases: 5; all passed
```

Reviewer: @smlambert 
FYI: @DanHeidinga @pshipton @Mesbah-Alam 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>