### PR TITLE
Increase threadsTimeout for transformer threads to finish

### DIFF
--- a/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/StringModifierAgent.java
+++ b/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/StringModifierAgent.java
@@ -42,7 +42,7 @@ public class StringModifierAgent {
 		int duration = 240; //in seconds.
 		Random randomNumberGenerator = new Random();
 		long seed = randomNumberGenerator.nextLong();
-		long threadsTimeout = 20*1000;
+		long threadsTimeout = 60*1000;
 		String debugOption = "";
 		
 		//Concatenate any command-line options with any env var options. 


### PR DESCRIPTION
- Increase threadsTimeout for transformer threads to finish - to resolve for intermittent failures. 
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>