### PR TITLE
Update asm to 7.3

### DIFF
--- a/openjdk.test.debugging/.classpath
+++ b/openjdk.test.debugging/.classpath
@@ -6,6 +6,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.load"/>
 	<classpathentry kind="lib" path="/systemtest_prereqs/tools/tools.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/asm-7.1/asm-7.1.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/asm-7.3/asm-7.3.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.debugging/build.xml
+++ b/openjdk.test.debugging/build.xml
@@ -46,9 +46,13 @@ limitations under the License.
 	<path id="project.class.path">
 		<path refid="junit.class.path" />
 		<path refid="stf.class.path" />
-		<path refid="asm.7.1.class.path" />
+		<path refid="asm.7.3.class.path" />
 		<path refid="tools.class.path" />
 	</path>
+	
+	<condition property="isJavas8" value="true">
+		<equals arg1="${java.specification.version}" arg2="1.8"/>
+	</condition>
 
 	<!-- Projects which need to be built before this one. -->
 	<!-- dir must be set on the ant task otherwise the basedir property is not set to a new value in the subant task. -->
@@ -91,7 +95,9 @@ limitations under the License.
 		</jar>
 	</target>
 
-	<target name="build-java" depends="check-prereqs, create-bin-dir">
+	<target name="build-java" depends="build-java-8, build-java-11-and-up" />
+		
+	<target name="build-java-8" if="${isJavas8}" depends="check-prereqs, create-bin-dir">
 		 <!--
 		 	The Ant javac task only checks time dependencies between .java files and their .class files,
 			so fails to recompile in situations such as the signatures of a dependent method changing.
@@ -113,6 +119,35 @@ limitations under the License.
 			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
+			<include name="**/*.java"/>
+		</javac>
+	</target>
+	
+	<target name="build-java-11-and-up" unless="${isJavas8}" depends="check-prereqs, create-bin-dir">
+		 <!--
+		 	The Ant javac task only checks time dependencies between .java files and their .class files,
+			so fails to recompile in situations such as the signatures of a dependent method changing.
+			The depend target checks the dependencies and deletes any .class files older than the files
+			which depend on them, thereby ensuring recompilation.
+		-->
+		<!--
+		Commented out because depend appears to be evaluating class files as always out of date with jdk11 (at 28/03/2019)
+		<depend srcdir="${openjdk_test_debugging_src_dir}" destdir="${openjdk_test_debugging_bin_dir}" classpathref="project.class.path">
+			<include name="**/*.java"/>
+		</depend>
+		-->
+		<javac srcdir="${openjdk_test_debugging_src_dir}"
+			   destdir="${openjdk_test_debugging_bin_dir}"
+			   fork="true"
+			   executable="${java_compiler}"
+			   debug="true"
+			   classpathref="project.class.path"
+			   encoding="${src-encoding}"
+			   includeantruntime="false"
+			   failonerror="true">
+			<compilerarg value="-source"/>
+			<compilerarg value="${java.specification.version}"/>
+			<compilerarg value="--enable-preview"/>
 			<include name="**/*.java"/>
 		</javac>
 	</target>

--- a/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/stf/hcrAgent/HCRLateAttachWorkload.java
+++ b/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/stf/hcrAgent/HCRLateAttachWorkload.java
@@ -1,5 +1,4 @@
 /*******************************************************************************
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -57,7 +56,7 @@ public class HCRLateAttachWorkload implements StfPluginInterface {
 		}
 		
 		// Specify the Process definition for the workload processes.
-		FileRef asmJar = test.env().findPrereqFile("/asm-7.1/asm-7.1.jar");
+		FileRef asmJar = test.env().findPrereqFile("/asm-7.3/asm-7.3.jar");
 		// Temporarily switched from using mini-mix to avoid test failures not related to HCR.
 		//String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		String inventoryFile = "/openjdk.test.load/config/inventories/util/util.xml";


### PR DESCRIPTION
- Update ASM references for 7.3 
- Update openjdk.test.debugging build file to add extra options (--enable-preview, -source)  when compiling on jdk11, and up (note JDK 8 doesn't support --enable-preview)
- Related to : https://github.com/eclipse/openj9/issues/8085

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>