### PR TITLE
Exclude Mauve sub-test DecimalFormat.setGroupingSize from jdk 14 openj9 for Single thread invocation variation of mauve test

### DIFF
--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleInvocationLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleInvocationLoadTest.java
@@ -60,6 +60,13 @@ public class MauveSingleInvocationLoadTest implements StfPluginInterface {
 			inventoryFile = "/openjdk.test.load/config/inventories/mauve/mauve_all_osx_openj9_jdk8.xml";
 		}
 		
+		/* Temporarily exclude DecimalFormat.setGroupingSize from openj9 jdk14 
+		Ref: https://github.com/eclipse/openj9/issues/8086
+		 */
+		if (jvm.isIBMJvm() 
+			&& jvm.getJavaVersion() == 14) {
+			inventoryFile = "/openjdk.test.load/config/inventories/mauve/mauve_all_openj9_jdk14.xml";
+		}
 		int numMauveTests = InventoryData.getNumberOfTests(test, inventoryFile);
 		
 		/*


### PR DESCRIPTION
Exclude for https://github.com/eclipse/openj9/issues/8086
https://github.com/AdoptOpenJDK/openjdk-systemtest/pull/322  missed similar exclude for the Single thread invocation variant of the Mauve load test - this PR adds it. 

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>