### PR TITLE
Exclude DecimalFormat.setGroupingSize from openj9 jdk15

### DIFF
--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveMultiThreadLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveMultiThreadLoadTest.java
@@ -60,11 +60,12 @@ public class MauveMultiThreadLoadTest implements StfPluginInterface {
 			inventoryFile = "/openjdk.test.load/config/inventories/mauve/mauve_multiThread_osx_openj9_jdk8.xml";
 		}
 		
-		/* Temporarily exclude DecimalFormat.setGroupingSize from openj9 jdk14 
+		/* Temporarily exclude DecimalFormat.setGroupingSize from openj9 jdk14 +
 			Ref: https://github.com/eclipse/openj9/issues/8086
+				 https://github.com/eclipse/openj9/issues/8620
 		 */
 		if (jvm.isIBMJvm() 
-			&& jvm.getJavaVersion() == 14) {
+			&& jvm.getJavaVersion() >= 14) {
 			inventoryFile = "/openjdk.test.load/config/inventories/mauve/mauve_multiThread_openj9_jdk14.xml";
 		}
 		

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleInvocationLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleInvocationLoadTest.java
@@ -60,11 +60,12 @@ public class MauveSingleInvocationLoadTest implements StfPluginInterface {
 			inventoryFile = "/openjdk.test.load/config/inventories/mauve/mauve_all_osx_openj9_jdk8.xml";
 		}
 		
-		/* Temporarily exclude DecimalFormat.setGroupingSize from openj9 jdk14 
-		Ref: https://github.com/eclipse/openj9/issues/8086
+		/* Temporarily exclude DecimalFormat.setGroupingSize from openj9 jdk14 +
+			Ref: https://github.com/eclipse/openj9/issues/8086
+			 	 https://github.com/eclipse/openj9/issues/8620
 		 */
 		if (jvm.isIBMJvm() 
-			&& jvm.getJavaVersion() == 14) {
+			&& jvm.getJavaVersion() >= 14) {
 			inventoryFile = "/openjdk.test.load/config/inventories/mauve/mauve_all_openj9_jdk14.xml";
 		}
 		int numMauveTests = InventoryData.getNumberOfTests(test, inventoryFile);

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleThreadLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleThreadLoadTest.java
@@ -60,11 +60,12 @@ public class MauveSingleThreadLoadTest implements StfPluginInterface {
 			inventoryFile = "/openjdk.test.load/config/inventories/mauve/mauve_all_osx_openj9_jdk8.xml";
 		}
 		
-		/* Temporarily exclude DecimalFormat.setGroupingSize from openj9 jdk14 
+		/* Temporarily exclude DecimalFormat.setGroupingSize from openj9 jdk14 +
 			Ref: https://github.com/eclipse/openj9/issues/8086
+			 	 https://github.com/eclipse/openj9/issues/8620
 		 */
 		if (jvm.isIBMJvm() 
-			&& jvm.getJavaVersion() == 14) {
+			&& jvm.getJavaVersion() >= 14) {
 			inventoryFile = "/openjdk.test.load/config/inventories/mauve/mauve_all_openj9_jdk14.xml";
 		}
 		


### PR DESCRIPTION
- Exclude for https://github.com/eclipse/openj9/issues/8620

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>