### PR TITLE
jck11 requires -source 11 instead of -source 9

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -766,6 +766,8 @@ public class Jck implements StfPluginInterface {
 				if (tests.contains("api/signaturetest") || tests.equals("api")) {
 					fileContent += "set jck.env.compiler.testCompile.compilerstaticsigtest.compilerStaticSigTestClasspathRemote \"" + getSignatureTestJars(pathToLib) + "\"" + ";\n";
 				}
+			} else if (jckVersion.contains("jck11")) {
+				fileContent += "set jck.env.compiler.testCompile.otherOpts \"-source 11 \"" + ";\n";
 			} else if (jckVersion.contains("jck12")) {
 				fileContent += "set jck.env.compiler.testCompile.otherOpts \"-release 12 --enable-preview\"" + ";\n";
 			} else if (jckVersion.contains("jck13")) {


### PR DESCRIPTION
**jck11 requires -source 11 instead of -source 9**

This is expected to fix following error.
```
warning: as of release 10, 'var' is a restricted local variable type and cannot be used for type declarations or as the element type of an array
        SAM s = (var i) -> i;
                 ^
../tests/lang/LMBD/lmbd182/lmbd18201m001/lmbd18201m001.java:21: error: cannot find symbol
        SAM s = (var i) -> i;
                 ^
  symbol:   class var
Number of errors: 1
```
Just added `jck11` case and didn't modified existing `jck9` just in case it is need for whatever reason. Assuming `jck10` is outdated.

Reviewer: @smlambert 


Signed-off-by: Jason Feng <fengj@ca.ibm.com>