### PR TITLE
Remove check for osx when using dump optioons

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -285,8 +285,7 @@ public class Jck implements StfPluginInterface {
 		// If we're testing a J9 VM that will result in dumps being taken and a non-zero return code
 		// which stf will detect as a failure. So in this case add the -Xdump options required to suppress
 		// taking dumps for OutOfMemory.
-		// Note -Xdump:system:none is unsupported on OSX
-		if (test.env().primaryJvm().isIBMJvm() && !PlatformFinder.isOSX()) {
+		if (test.env().primaryJvm().isIBMJvm()) {
 			suppressOutOfMemoryDumpOptions = " -Xdump:system:none -Xdump:system:events=gpf+abort+traceassert+corruptcache -Xdump:snap:none -Xdump:snap:events=gpf+abort+traceassert+corruptcache -Xdump:java:none -Xdump:java:events=gpf+abort+traceassert+corruptcache -Xdump:heap:none -Xdump:heap:events=gpf+abort+traceassert+corruptcache";
 		}
 	}


### PR DESCRIPTION
Resolves https://github.ibm.com/runtimes/backlog/issues/284
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>