### PR TITLE
Add linux_390-32 and zos_390-32 to supported list of PLATFORMS

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -164,7 +164,7 @@ ifeq ($(PLATFORM),aix_ppc-64)
 	LDFLAGS=-G 
 endif
 
-ifeq ($(PLATFORM),linux_390-31)
+ifeq ($(PLATFORM),linux_390-32)
 	CC=gcc
 	CFLAGS=-m31 -fPIC -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
 	LDFLAGS=-shared
@@ -188,7 +188,7 @@ ifeq ($(PLATFORM),linux_arm-64)
 	LDFLAGS=-shared
 endif
 
-ifeq ($(PLATFORM),zos_390-31)
+ifeq ($(PLATFORM),zos_390-32)
 	CC=c89
 	CFLAGS=-I$(SRCDIR)/src/share/lib/jni/include/unix -I$(SRCDIR)/src/share/lib/jni/include -I$(FULLOUTDIR)/include -I$(SRCDIR)/src -Wc,ASCII -W"c,xplink(backchain,oscall(downstack)),noansialias,float(ieee),langlvl(extended),ROCONST,ROSTRING,enum(4),noupconv,sscom" -W"c,target(zOSV2R2)" -W"c,inline(auto,noreport,1200,8000)" -W"a,goff,ESD" -W"c,dll,expo" -W"l,xplink,compat=min" -Wl,dll -Ds390 -DARCH='"s390"'
 	LDFLAGS=-D_ALL_SOURCE -DUSE_MALLOC -DIBM_STACK_GROWS_UP -D_XOPEN_SOURCE_EXTENDED=1 -DIBM_ATOE -DOS390CTRACE -DIBM_WRITE_BARRIER -DIBM_MVS -DASYNCH_FI -DRASTRACE_TDF -DJNI_JCL_H -DIBM_ALL -DIBM_UNIX -D_POSIX_SOURCE -DSOLARIS2 -DIBM_OE_XWINDOWS -DIBM_NOAUDIO -DIBM_OE -DIBM_BUILD_TYPE_int -DJ9J2SE -D_BIG_ENDIAN -D_UNIX03_SOURCE -DSTDC -D_LARGE_FILES 
@@ -309,11 +309,11 @@ help:
 	@echo   linux_ppc-32
 	@echo   linux_ppcle-64
 	@echo   linux_ppc-64
-	@echo   linux_390-31
+	@echo   linux_390-32
 	@echo   linux_390-64
 	@echo   win_x86-32
 	@echo   win_x86-64
-	@echo   zos_390-31
+	@echo   zos_390-32
 	@echo   zos_390-64
 	@echo   hp_ux-32
 	@echo   hp_ux-64

--- a/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
+++ b/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
@@ -52,7 +52,7 @@ P=:
 ###
 # Check platform is set to a single valid value
 ###
-VALID_PLATFORMS?=osx_x86-64,aix_ppc-32,aix_ppc-64,linux_390-31,linux_390-64,linux_ppc-32,linux_ppc-64,linux_x86-32,linux_x86-64,win_x86-32,win_x86-64,zos_390-31,zos_390-64,linux_ppcle-64,linux_arm-32,linux_arm-64,bsd_x86-64
+VALID_PLATFORMS?=osx_x86-64,aix_ppc-32,aix_ppc-64,linux_390-32,linux_390-64,linux_ppc-32,linux_ppc-64,linux_x86-32,linux_x86-64,win_x86-32,win_x86-64,zos_390-32,zos_390-64,linux_ppcle-64,linux_arm-32,linux_arm-64,bsd_x86-64
 ifndef PLATFORM
   $(error "The variable PLATFORM needs to be defined")
 endif
@@ -95,7 +95,7 @@ ifeq ($(PLATFORM),linux_ppcle-64)
     LFLAGS=-L. -L../bin/$(PLATFORM) -m64 -shared -o 
 endif
 
-ifeq ($(PLATFORM),linux_390-31)
+ifeq ($(PLATFORM),linux_390-32)
     CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m31 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
     LFLAGS=-m31 -shared -o
 endif
@@ -195,7 +195,7 @@ ifeq ($(PLATFORM),zos_390-64)
     RMLIST=*.o *.x
 endif
 
-ifeq ($(PLATFORM),zos_390-31)
+ifeq ($(PLATFORM),zos_390-32)
     CC=c89
     LD=c89
 


### PR DESCRIPTION
Add linux_390-32 and zos_390-32 to the list of supported platforms in test build script.
Background: backlog/issues/307
FYI @lumpfish 
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>