### PR TITLE
Add compiler coptions for linux ppc 32 bit platform to modularity native build script

### DIFF
--- a/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
+++ b/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
@@ -85,6 +85,11 @@ ifeq ($(PLATFORM),linux_x86-64)
 	LFLAGS=-shared -m64 -o 
 endif
 
+ifeq ($(PLATFORM),linux_ppc-32)
+    CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m32 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
+    LFLAGS=-L. -L../bin/$(PLATFORM) -m32 -shared -o 
+endif
+
 ifeq ($(PLATFORM),linux_ppc-64)
     CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m64 -mcpu=powerpc64 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
     LFLAGS=-L. -L../bin/$(PLATFORM) -m64 -shared -o 


### PR DESCRIPTION
- Add compiler flags and options for linux ppc 32 bit platform to modularity native build script
- Resolves https://github.ibm.com/runtimes/backlog/issues/308

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>