### PR TITLE
Add xdump options to mauve tests for MauveTestFailureException

### DIFF
--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveMultiThreadTestTrc.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveMultiThreadTestTrc.java
@@ -77,7 +77,7 @@ public class MauveMultiThreadTestTrc implements StfPluginInterface {
 
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addJvmOption(modularityOptions)
-				.addJvmOption("\"-Xtrace:iprint=mt,trigger=method{java/util/Locale.setDefault*,jstacktrace}\"")
+				.addJvmOption("-Xdump:system:events=throw,filter=net/adoptopenjdk/loadTest/MauveTestFailureException,range=1..1,request=exclusive+prepwalk")
 				.addJarToClasspath(mauveJar)
 				.addSuite("mauve")
 				.setSuiteInventory(inventoryFile)

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleThreadTestTrc.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleThreadTestTrc.java
@@ -67,7 +67,7 @@ public class MauveSingleThreadTestTrc implements StfPluginInterface {
 		
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addJvmOption(modularityOptions)
-				.addJvmOption("\"-Xtrace:iprint=mt,trigger=method{java/util/Locale.setDefault*,jstacktrace}\"")
+				.addJvmOption("-Xdump:system:events=throw,filter=net/adoptopenjdk/loadTest/MauveTestFailureException,range=1..1,request=exclusive+prepwalk")
 				.addJarToClasspath(mauveJar)
 				.addSuite("mauve")
 				.setSuiteInventory(inventoryFile)


### PR DESCRIPTION
- Add xdump options to mauve tests for MauveTestFailureException
- Related to https://github.com/AdoptOpenJDK/stf/issues/81
Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>