### PR TITLE
Exclude SolverTest

### DIFF
--- a/openjdk.test.load/config/inventories/util/util_exclude.xml
+++ b/openjdk.test.load/config/inventories/util/util_exclude.xml
@@ -1,0 +1,4 @@
+<inventory> 
+	<!--  Disabled due to https://github.com/AdoptOpenJDK/openjdk-tests/issues/1916 -->
+	<junit class="net.adoptopenjdk.test.util.solver.SolverTest"/>
+</inventory>


### PR DESCRIPTION
This test fails as per the referenced issue. Excluding the
test for now to make triage faster.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>