### PR TITLE
Add null check to StringTransformer

### DIFF
--- a/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/StringTransformer.java
+++ b/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/StringTransformer.java
@@ -64,7 +64,7 @@ public class StringTransformer implements ClassFileTransformer {
 				byte[] classfileBuffer) throws IllegalClassFormatException {
 		byte[] newClassFileBuffer = classfileBuffer;
 		try {
-			if (className.equals("java/lang/String")) {
+			if ((className != null) && className.equals("java/lang/String")) {
 				AgentLogger.printThis("Thread " + threadNumber + "'s transformer is now transforming String.",2);
 				//Step 1: Make a Reader.
 				ClassReader cr = new ClassReader(newClassFileBuffer);


### PR DESCRIPTION
If a class is defined after an instance of StringTransformer is registered,
the transform method will be called and passed a null className as the new
class is being defined. This will throw an exception and end the test so we
need to ensure the className is not null before the equality check.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/eclipse/openj9/issues/10504
