### PR TITLE
Fix openjdk.test.jck build script

### DIFF
--- a/openjdk.test.jck/build.xml
+++ b/openjdk.test.jck/build.xml
@@ -35,6 +35,17 @@ limitations under the License.
 	</loadresource>
 	<property name="jck_runtimes_src_dir" value="${env.JCK_ROOT}/JCK-runtime-${jck_short_version}"/>
 
+	<!--Clean up possible leading or trailing spaces from jck_runtime_src_dir-->
+	<loadresource property="jck_runtimes_src_dir_cleaned">
+  		<propertyresource name="jck_runtimes_src_dir"/>
+  			<filterchain>
+    				<tokenfilter>
+      					<filetokenizer/>
+      						<replacestring from=" " to=""/>
+    				</tokenfilter>
+  			</filterchain>
+	</loadresource>
+	
 	<!-- Import settings used by multiple projects.  -->
 	<import file="${stf_root}/stf.build/include/top.xml"/>
 
@@ -47,14 +58,14 @@ limitations under the License.
 
 	<condition property="can_build_jck_natives_windows" value="true">
 		<and>
-			<available file="${jck_runtimes_src_dir}" type="dir"/>
+			<available file="${jck_runtimes_src_dir_cleaned}" type="dir"/>
 			<equals arg1="${is_windows}" arg2="true"/>
 			<equals arg1="${windows_native_compiler_present}" arg2="true"/>
 		</and>
 	</condition>
 	<condition property="can_build_jck_natives_unix" value="true">
 		<and>
-			<available file="${jck_runtimes_src_dir}" type="dir"/>
+			<available file="${jck_runtimes_src_dir_cleaned}" type="dir"/>
 			<not>
 				<equals arg1="${is_windows}" arg2="true"/>
 			</not>
@@ -117,7 +128,7 @@ limitations under the License.
 	
 	<target name="setup-native-build-command">
 		<echo message="building natives for java_platform ${java_platform}"/>
-		<property name="openjdk_test_jck_native_build_command" value='${setup_windows_build_env}make build -f ${jck_makefile_dir}/makefile SRCDIR=${jck_runtimes_src_dir} PLATFORM=${java_platform} JAVA_HOME=${TEST_JDK_HOME} OUTDIR=${out_dir}'/>
+		<property name="openjdk_test_jck_native_build_command" value='${setup_windows_build_env}make build -f ${jck_makefile_dir}/makefile SRCDIR=${jck_runtimes_src_dir_cleaned} PLATFORM=${java_platform} JAVA_HOME=${TEST_JDK_HOME} OUTDIR=${out_dir}'/>
 		<tempfile property="openjdk_test_jck_native_build_command_file" destDir="${java.io.tmpdir}" prefix="openjdk.build.command."/>
 	</target>
 


### PR DESCRIPTION
- Adds logic to remove any possible leading or trailing spaces from ${jck_runtimes_src_dir}

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>