### PR TITLE
Add System.gc() calls to allow native memory to be reclaimed

### DIFF
--- a/openjdk.test.gc/src/test.gc/net/adoptopenjdk/test/gc/directbytebuffer/DirectMemoryTest.java
+++ b/openjdk.test.gc/src/test.gc/net/adoptopenjdk/test/gc/directbytebuffer/DirectMemoryTest.java
@@ -40,6 +40,12 @@ public class DirectMemoryTest extends TestCase {
 				bbStore[i] = ByteBuffer.allocateDirect(ALLOC_SIZE);
 				// *** dereference to allow GC
 				bbStore[i] = null;
+				
+				// Allow GC to happen so that native memory is reclaimed 
+				if (i % 5 == 0) {
+					System.gc();
+					System.gc();
+				}
 			}
 			
 			assertTrue(i==ITERATIONS);

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/DirectByteBufferLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/DirectByteBufferLoadTest.java
@@ -53,6 +53,7 @@ public class DirectByteBufferLoadTest implements StfPluginInterface {
 		int cpuCount = Runtime.getRuntime().availableProcessors();
 		
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
+				.addJvmOption("-Xmx512m")
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
 				.addJarToClasspath(filesystemJar)


### PR DESCRIPTION
- Related to https://github.com/eclipse/openj9/issues/11112

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>

