### PR TITLE
Exclude Mauve[gnu.testlet.java.lang.NullPointerException.constructor]

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -1047,7 +1047,9 @@
 	<mauve class="gnu.testlet.javax.swing.ViewportLayout.minimumLayoutSize"/>
 	<mauve class="gnu.testlet.javax.net.ssl.SSLContext.TestGetInstance"/>
 	<mauve class="gnu.testlet.java.security.SecureRandom.SHA1PRNG"/>
-	
+
+	<!-- Excluded due to https://github.com/eclipse/openj9/issues/11206 -->
+	<mauve class="gnu.testlet.java.lang.NullPointerException.constructor"/>
 	<!-- Excluded due to https://bugs.openjdk.java.net/browse/JDK-8231851 -->
 	<mauve class="gnu.testlet.java.text.DecimalFormat.setGroupingSize"/>
 	<!-- Fails on jdk12 hotspot with: 

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -1,4 +1,7 @@
 <inventory>
+	<!-- Excluded due to https://github.com/eclipse/openj9/issues/11206 -->
+	<mauve class="gnu.testlet.java.lang.NullPointerException.constructor"/>
+
 	<!--  Disabled due to https://github.com/eclipse/openj9/issues/8204 -->
 	<mauve class="gnu.testlet.java.util.SimpleTimeZone.inDaylightTime"/>
 	<mauve class="gnu.testlet.java.util.SimpleTimeZone.hashCode"/>


### PR DESCRIPTION
Exclude Mauve[gnu.testlet.java.lang.NullPointerException.constructor]

related: https://github.com/eclipse/openj9/issues/11206

Signed-off-by: Jason Feng <fengj@ca.ibm.com>