### PR TITLE
Use mauve_multiThread load in mix-more load configuration

### DIFF
--- a/openjdk.test.load/config/inventories/mix/mix-more.xml
+++ b/openjdk.test.load/config/inventories/mix/mix-more.xml
@@ -5,7 +5,7 @@
 
 <inventory>
 	<include inventory="/openjdk.test.load/config/inventories/math/bigdecimal.xml"/>
-	<include inventory="/openjdk.test.load/config/inventories/mauve/mauve_all.xml"/>
+	<include inventory="/openjdk.test.load/config/inventories/mauve/mauve_multiThread.xml"/>
 	<include inventory="/openjdk.test.load/config/inventories/lang/lang.xml"/>
 	<include inventory="/openjdk.test.load/config/inventories/nio/nio.xml"/>
 	<include inventory="/openjdk.test.load/config/inventories/concurrent/concurrent.xml"/>


### PR DESCRIPTION
MiniMix load test runs [mix-more.xml ](https://github.com/AdoptOpenJDK/openjdk-systemtest/blob/master/openjdk.test.load/config/inventories/mix/mix-more.xml) load inventory using more than 1 thread. 

mix-more.xml runs [mauve_all.xml](https://github.com/AdoptOpenJDK/openjdk-systemtest/blob/master/openjdk.test.load/config/inventories/mix/mix-more.xml#L8) load. 

However, all exclusions for mauve multi-threaded scenario are in  [mauve_multiThread.xml](https://github.com/AdoptOpenJDK/openjdk-systemtest/blob/master/openjdk.test.load/config/inventories/mauve/mauve_multiThread.xml). 

This may end up running mauve sub-tests which should not be run in multi-threaded scenario, e.g. tests that enable SecurityManager. 
 
This PR updates mix-more.xml configuration by specifying `mauve_multiThread.xml` to be run in the mix. This way we'd be using [mauve_multiThread_exclude.xml](https://github.com/AdoptOpenJDK/openjdk-systemtest/blob/master/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml) during test load, which contains the set of exclusions applicable for multi-threaded load run. 

Related to https://github.com/eclipse/openj9/issues/11534

