### PR TITLE
Exclude sub-test incompatible with jdk16+ HotSpot

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -1,4 +1,8 @@
 <inventory>
+	<!-- Disabled as the following sub-tests are incompatible with jdk16 on HotSpot -->
+	<!-- Details in issue: https://github.com/AdoptOpenJDK/openjdk-tests/issues/2150 -->
+	<mauve class="gnu.testlet.java.util.HashMap.AcuniaHashMapTest"/>
+	
 	<!-- Disabled as the following tests load awt libraries that are not thread-safe and cause hang on osx openj9 jdk8 : https://github.com/eclipse/openj9/issues/7050 -->
 	<mauve class="gnu.testlet.java.text.AttributedCharacterIterator.getRunLimit"/>
 	<mauve class="gnu.testlet.java.text.AttributedCharacterIterator.getRunStart"/>

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -1,4 +1,8 @@
 <inventory>
+	<!-- Disabled as the following sub-tests are incompatible with jdk16 on HotSpot -->
+	<!-- Details in issue: https://github.com/AdoptOpenJDK/openjdk-tests/issues/2150 -->
+	<mauve class="gnu.testlet.java.util.HashMap.AcuniaHashMapTest"/>
+	
 	<!--  Disabled due to https://github.com/eclipse/openj9/issues/8204 -->
 	<mauve class="gnu.testlet.java.util.SimpleTimeZone.inDaylightTime"/>
 	<mauve class="gnu.testlet.java.util.SimpleTimeZone.hashCode"/>


### PR DESCRIPTION
- Exclude sub-test incompatible with jdk16+ HotSpot to allow MiniMix system test to work on HotSpot JDk16+
- Related to https://github.com/AdoptOpenJDK/openjdk-tests/issues/2150


Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>