### PR TITLE
Set timeout of sub-test to a reasonable value

### DIFF
--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MathLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MathLoadTest.java
@@ -34,7 +34,7 @@ import net.adoptopenjdk.stf.runner.modes.HelpTextGenerator;
 public class MathLoadTest implements StfPluginInterface {
 	private enum Workloads {
 		//Workload  Multiplier  Timeout  InventoryFile
-		math( 		   50, 		 "20h", 	"math.xml"),
+		math( 		   50, 		 "2h", 	"math.xml"),
 		bigDecimal(    50,		 "1h", 		"bigdecimal.xml"),
 		autoSimd( 	   4000, 	 "5m", 		"autosimd.xml");
 		


### PR DESCRIPTION
This PR reduces the 'math' variant of math load test's timeout value from `20h` to `2h`- which is a more practical timeout value. This prevents cases like the one reported [here](https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/389#issuecomment-756862024) where the test took more than 5 hours to complete. 

Related to https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/389

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>