### PR TITLE
Remove hard-coded version numbers from prereq jar references

### DIFF
--- a/openjdk.test.classloading/.classpath
+++ b/openjdk.test.classloading/.classpath
@@ -3,8 +3,8 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.load"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/hamcrest-core-1.3.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/hamcrest-core.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry excluding="notonclasspath/" kind="src" output="bin" path="src/test.classloading"/>
 	<classpathentry kind="output" path="bin"/>
 	<classpathentry kind="src" output="bin_notonclasspath/url1" path="src/test.classloading/notonclasspath/url1"/>

--- a/openjdk.test.concurrent/.classpath
+++ b/openjdk.test.concurrent/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src/test.concurrent"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.debugging/.classpath
+++ b/openjdk.test.debugging/.classpath
@@ -2,10 +2,10 @@
 <classpath>
 	<classpathentry kind="src" path="src/test.debugging"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.load"/>
 	<classpathentry kind="lib" path="/systemtest_prereqs/tools/tools.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/asm-9.0/asm-9.0.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/asm/asm.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/stf/hcrAgent/HCRLateAttachWorkload.java
+++ b/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/stf/hcrAgent/HCRLateAttachWorkload.java
@@ -56,7 +56,7 @@ public class HCRLateAttachWorkload implements StfPluginInterface {
 		}
 		
 		// Specify the Process definition for the workload processes.
-		FileRef asmJar = test.env().findPrereqFile("/asm-9.0/asm-9.0.jar");
+		FileRef asmJar = test.env().findPrereqFile("/asm/asm.jar");
 		// Temporarily switched from using mini-mix to avoid test failures not related to HCR.
 		//String inventoryFile = "/openjdk.test.load/config/inventories/mix/mini-mix.xml";
 		String inventoryFile = "/openjdk.test.load/config/inventories/util/util.xml";

--- a/openjdk.test.gc/.classpath
+++ b/openjdk.test.gc/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src/test.gc"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.jck/.classpath
+++ b/openjdk.test.jck/.classpath
@@ -3,8 +3,8 @@
 	<classpathentry kind="src" path="src/test.jck"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/log4j-2.13.3/log4j-api-2.13.3.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/log4j-2.13.3/log4j-core-2.13.3.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/log4j/log4j-api.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/log4j/log4j-core.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.jck/build.xml
+++ b/openjdk.test.jck/build.xml
@@ -64,7 +64,7 @@ limitations under the License.
 	<!-- We need junit, log4j and stf to compile this project. -->
 	<path id="project.class.path">
 		<path refid="junit.class.path" />
-		<path refid="log4j-2.13.3.class.path" />
+		<path refid="log4j.class.path" />
 		<path refid="stf.class.path" />
 	</path>
 

--- a/openjdk.test.jck/docs/README.md
+++ b/openjdk.test.jck/docs/README.md
@@ -77,7 +77,7 @@ git repositories and the test and prereqs (including the JCK):
 /home/user/git/openjdk-systemtests
 /home/user/git/openjdk-systemtests/........       <- openjdk-systemtest repository files
 /home/user/systemtest_prereqs
-/home/user/systemtest_prereqs/junit-4.12/........ <- junit files
+/home/user/systemtest_prereqs/junit/........      <- junit files
 /home/user/systemtest_prereqs/jck
 /home/user/systemtest_prereqs/jck/jck8b           <- Java 8 JCK (jck8b) files
 /home/user/systemtest_prereqs/.........           <- other prereq directories

--- a/openjdk.test.jlm/.classpath
+++ b/openjdk.test.jlm/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/test.jlm"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>

--- a/openjdk.test.lambdasAndStreams/.classpath
+++ b/openjdk.test.lambdasAndStreams/.classpath
@@ -2,8 +2,8 @@
 <classpath>
 	<classpathentry kind="src" path="src/test.lambda"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/hamcrest-core-1.3.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/hamcrest-core.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.lang/.classpath
+++ b/openjdk.test.lang/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="src" path="src/test.lang"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.load/.classpath
+++ b/openjdk.test.load/.classpath
@@ -4,7 +4,7 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.load"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/hamcrest-core-1.3.jar"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/hamcrest-core.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.math/.classpath
+++ b/openjdk.test.math/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src/test.math"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/ExplMod.java
+++ b/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/ExplMod.java
@@ -56,8 +56,8 @@ public class ExplMod implements StfPluginInterface {
 		FileRef junitPath = test.env().getJarLocation(JavaProcessDefinition.JarId.JUNIT);
 		FileRef hamcrestPath = test.env().getJarLocation(JavaProcessDefinition.JarId.HAMCREST);
 		
-		String explicitModule_JunitJarName = "junit-4.12.jar";
-		String explicitModule_HamcrestJarName = "hamcrest-core-1.3.jar";
+		String explicitModule_JunitJarName = "junit.jar";
+		String explicitModule_HamcrestJarName = "hamcrest-core.jar";
 		DirectoryRef testsDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests");
 		
 		// Create necessary modular jars 
@@ -112,7 +112,7 @@ public class ExplMod implements StfPluginInterface {
 						.setJDKToolOrUtility("jar")	
 						.addArg("-xf " + junitCopy.childFile(explicitModule_JunitJarName).getSpec() ));
 		
-		// Compile the module-info.java generated for junit-4.12.jar and update the module-info.class in the jar file.
+		// Compile the module-info.java generated for junit.jar and update the module-info.class in the jar file.
 		test.doRunForegroundProcess("Compiling the module info", "JAVC", ECHO_ON, ExpectedOutcome.cleanRun().within("1m"), 
 					test.createJDKToolProcessDefinition()
 						.setJDKToolOrUtility("javac")	

--- a/openjdk.test.nio/.classpath
+++ b/openjdk.test.nio/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src/test.nio"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/stf.core"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.serialization/.classpath
+++ b/openjdk.test.serialization/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src/test.serialization"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/openjdk.test.util/.classpath
+++ b/openjdk.test.util/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src/test.util"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/systemtest_prereqs/junit-4.12/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/systemtest_prereqs/junit/junit.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
- Removes version number from all prereq jar references in openjdk-systemtest repo
- Related to : https://github.com/AdoptOpenJDK/stf/issues/98

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>