### PR TITLE
Have a reduced workload in MathLoadTest and ClassLoadinngLoadTest for all slow running JIT options

### DIFF
--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ClassloadingLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/ClassloadingLoadTest.java
@@ -43,22 +43,25 @@ public class ClassloadingLoadTest implements StfPluginInterface {
 	}
 
 	public void pluginInit(StfCoreExtension stf) throws StfException {
-		if (stf.isJavaArgPresent(Stage.EXECUTE, "-Xjit:count=0,optlevel=warm,gcOnResolve,rtResolve") ||
-			stf.isJavaArgPresent(Stage.EXECUTE, "-Xjit:enableOSR,enableOSROnGuardFailure,count=1,disableAsyncCompilation")) {
-				specialTest = true;
-			}
-			
-			if(specialTest) {
-				// If we are running with special JIT modes which are slow, reduce workload 
-				testCountMultiplier = 1500; 
-				
-			} 	
 	}
 
 	public void setUp(StfCoreExtension test) throws StfException {
 	}
 
 	public void execute(StfCoreExtension test) throws StfException {
+		String jvmOptionsInUse = test.getJavaArgs(test.env().primaryJvm()); 
+		
+		if (jvmOptionsInUse.contains("-Xjit:count") ||
+			jvmOptionsInUse.contains("Xjit:enableOSR")) {
+			specialTest = true;
+		}
+		
+		if(specialTest) {
+			// If we are running with special JIT modes which are slow, reduce workload 
+			testCountMultiplier = 500; 
+			
+		} 	
+		
 		String inventoryFile = "/openjdk.test.load/config/inventories/classloading/classloading.xml";
 		int totalTests = InventoryData.getNumberOfTests(test, inventoryFile);
 		int cpuCount = Runtime.getRuntime().availableProcessors();


### PR DESCRIPTION
- The logic of how the tests figure out when slow running JIT modes are in effect has been modified. Now the test will treat any JIT option that contains `-Xjit:count` or `Xjit:enableOSR` (e.g. Mode614, Modew553, etc and the OSR modes) as slow running options and use a reduced workload. This will now ensure we do not run the "regular" (longer) load when any of these JIT modes are in use.

- Related to https://github.com/eclipse/openj9/issues/11666

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>