### PR TITLE
Fix HCRLateAttachWorkload_previewEnabled failure on jdk17

### DIFF
--- a/openjdk.test.debugging/build.xml
+++ b/openjdk.test.debugging/build.xml
@@ -37,6 +37,8 @@ limitations under the License.
 	<!-- For modularity you need a directory above the package structure to hold the module.java file -->
 	<property name="openjdk_test_debugging_module" value="test.debugging" />
 	<property name="openjdk_test_debugging_src_dir" value="src/${openjdk_test_debugging_module}" />
+	<property name="openjdk_test_debugging_src_80_dir" value="src_80/${openjdk_test_debugging_module}" />
+	<property name="openjdk_test_debugging_src_110_dir" value="src_110/${openjdk_test_debugging_module}" />
 	<property name="openjdk_test_debugging_bin_dir" value="bin" />
 
 	<property name="openjdk_test_debugging_jdi_jar_file" value="${openjdk_test_debugging_bin_dir}/JdiTests.jar" />
@@ -119,7 +121,8 @@ limitations under the License.
 			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
-			<include name="**/*.java"/>
+			<src path="${openjdk_test_debugging_src_dir}" />
+			<src path="${openjdk_test_debugging_src_80_dir}" />
 		</javac>
 	</target>
 	
@@ -136,6 +139,7 @@ limitations under the License.
 			<include name="**/*.java"/>
 		</depend>
 		-->
+		<property name="addExports" value="--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED" />
 		<javac srcdir="${openjdk_test_debugging_src_dir}"
 			   destdir="${openjdk_test_debugging_bin_dir}"
 			   fork="true"
@@ -145,10 +149,12 @@ limitations under the License.
 			   encoding="${src-encoding}"
 			   includeantruntime="false"
 			   failonerror="true">
+			<src path="${openjdk_test_debugging_src_dir}" />
+			<src path="${openjdk_test_debugging_src_110_dir}" />
 			<compilerarg value="-source"/>
 			<compilerarg value="${java.specification.version}"/>
 			<compilerarg value="--enable-preview"/>
-			<include name="**/*.java"/>
+			<compilerarg line='${addExports}' />
 		</javac>
 	</target>
 	

--- a/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/StringTransformer.java
+++ b/openjdk.test.debugging/src/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/StringTransformer.java
@@ -18,10 +18,10 @@ package net.adoptopenjdk.test.hcrAgent.agent;
 import java.lang.instrument.ClassFileTransformer;
 import java.security.ProtectionDomain;
 import java.lang.instrument.IllegalClassFormatException;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.ClassVisitor;
 
 /*
  * This class allows us to take an existing class' byte code and pass it through our modifier code.

--- a/openjdk.test.debugging/src_110/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyClassVisitor.java
+++ b/openjdk.test.debugging/src_110/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyClassVisitor.java
@@ -15,9 +15,9 @@ limitations under the License.
 
 package net.adoptopenjdk.test.hcrAgent.agent;
 
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
 import java.util.Random;
 
 /*

--- a/openjdk.test.debugging/src_110/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyMethodVisitor.java
+++ b/openjdk.test.debugging/src_110/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyMethodVisitor.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.test.hcrAgent.agent;
+
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
+
+/*
+ * This class inserts new byte codes into an existing Java class.
+ * An ASM ClassReader can take Java byte codes and call the relevant
+ * methods in a ClassWriter to build a copy of that class. We can intercept
+ * these calls and insert our own code instead (or as well).
+ */
+public class MyMethodVisitor extends MethodVisitor {
+	private String methodNameLocal;
+	private int randomNumber;
+	private int threadNumber;
+	/**
+	 * The constructor for this class.
+	 * @param mv           The MethodVisitor representing the method we're modifying. Receives all method calls we don't override. 
+	 * @param methodName   The name of the method we're modifying
+	 * @param randomNumber Used to select which method call we're adding to this method.
+	 * @param threadNumber Used to generate thread-specific log messages, as many of these may be running at once.
+	 */
+	public MyMethodVisitor(MethodVisitor mv, String methodName, int randomNumber, int threadNumber) {
+		super(Opcodes.ASM7, mv);
+		methodNameLocal = methodName;
+		this.randomNumber = randomNumber;
+		this.threadNumber = threadNumber;
+	}
+
+	/**
+	 * This method is called when we're telling the ClassWriter to start a new method.
+	 * We pass this call on, and then add our code before the ClassReader can tell the 
+	 * MethodVisitor to construct the code present in the old version of this method.
+	 */
+	@Override
+	public void visitCode() {
+		mv.visitCode();
+		randomMethodCall();
+	}
+
+	/**
+	 * This method takes the size of the operand stack associated with the method 
+	 * represented by "mv"and increments it by 2.
+	 * That change ensures we have the necessary space for our new variables.
+	 * @param x The size of mv's method's execution frame's operand stack.
+	 * @param y The size of mv's method's local variable array.
+	 */
+	@Override
+	public void visitMaxs(int x, int y) {
+		mv.visitMaxs(x+2,y);
+	}
+
+	/**
+	 * This method writes new bytecodes that do setup for, 
+	 * and call, a random method in one of Java's core classes.
+	 * If you want to add more methods, please remember to:
+	 * a) Pick a class that is central to Java, so we know String can access it.
+	 * b) Increase the visitMaxs "+" to reflect the number of 
+	 * 	operands on the stack at any one time.
+	 * and c) Clean up after, by popping all values off of the stack.
+	 */
+	private void randomMethodCall(){
+		randomNumber = randomNumber % 4;
+		//0: Calling static method System.currentTimeMillis()J;
+		//1: Calling static method Integer.compare(II)I;
+		//2: Calling method Object.hashCode()I;
+		//3: Calling static method Thread.activeCount()I;
+		switch (randomNumber) {
+			case 0 : mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/System", "currentTimeMillis", "()J", false);
+				 mv.visitInsn(Opcodes.POP2);
+				 announceChangeMade("System.currentTimeMillis()J");
+				 break;
+			case 1 : mv.visitInsn(Opcodes.ICONST_0);
+				 mv.visitInsn(Opcodes.ICONST_1);
+				 mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Integer", "compare", "(II)I", false);
+				 mv.visitInsn(Opcodes.POP);
+				 announceChangeMade("Integer.compare(II)I");
+				 break;
+			case 2 : mv.visitTypeInsn(Opcodes.NEW, "java/lang/Object");
+				 mv.visitInsn(Opcodes.DUP);
+				 mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+				 mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/Object", "hashCode", "()I", false);
+				 mv.visitInsn(Opcodes.POP);
+				 announceChangeMade("Object.hashCode()I");
+				 break;
+			case 3 : mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Thread", "activeCount", "()I", false);
+				 mv.visitInsn(Opcodes.POP);
+				 announceChangeMade("Thread.activeCount()I");
+				 break;
+		}
+	}
+
+	public void announceChangeMade(String callAdded){
+		AgentLogger.printThis("Thread " + threadNumber + "'s MethodVisitor successfully added a " + callAdded + " call to the start of the String." + methodNameLocal + " method.",2);
+	}
+}
+

--- a/openjdk.test.debugging/src_80/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyClassVisitor.java
+++ b/openjdk.test.debugging/src_80/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyClassVisitor.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.test.hcrAgent.agent;
+
+import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import java.util.Random;
+
+/*
+ * This class sits between a ClassReader and a ClassWriter. The former can read the 
+ * bytecodes of an existing class, and the latter can form new bytecodes. The Reader 
+ * can tell the Writer how to reproduce the class it is "reading". Our layer in the 
+ * middle allows us to change those instructions to the Writer, which (in this case)
+ * results in the creation of new method calls at the start of some methods.
+ */
+
+public class MyClassVisitor extends ClassVisitor {
+	
+	// Percentage of methods we want to modify.
+	int percentage;
+	int threadNumber;
+	// Number generator to decide if we want to visit a specific method.
+	Random randomNumberGenerator;	
+
+	/**
+	 * Constructor.
+	 * @param  cv         The ClassVisitor we forward method calls to, 
+	 * @param  percentage The average percentage of public methods we want to transform.
+	 */
+	public MyClassVisitor(ClassVisitor cv, int percentage, long seed, int threadNumber) {
+		super(Opcodes.ASM4, cv);
+		this.percentage = percentage;
+		randomNumberGenerator = new Random(seed);
+		this.threadNumber = threadNumber;
+	}
+
+	/**
+	 * This method is called when the ClassReader tells the ClassWriter that,
+	 * in the class it is reading, there is a method here. The returned MethodVisitor
+	 * allows the ClassReader to tell the ClassWriter what code should be in there.
+	 * We intercept this call to allow us to add some new method calls to this method,
+	 * before the ClassReader gets a change to populate it.
+	 * @param  access     The accesses (e.g. public, private) of the method we're making. 
+	 * @param  name       The name of the method we're making.
+	 * @param  desc       The descriptor of the method we're making.
+	 * @param  signature  The signature of the method we're making.
+	 * @param  exceptions The exceptions thrown by the method we're making.
+	 * @return     The MethodVisitor representing the method we're telling the ClassWriter to create.
+	 */
+	@Override
+	public MethodVisitor visitMethod(int access, String name,
+		String desc, String signature, String[] exceptions) {
+		MethodVisitor mv;
+		mv = cv.visitMethod(access, name, desc, signature, exceptions);
+		int randomNumber = randomNumberGenerator.nextInt(100) + 1;
+		// MyMethodVisitor will add a random method call to the method we're working on if:
+		// 1) The MethodVisitor isn't null (null = the ClassVisitor "cv" does not want to visit the method).
+		// 2) The method isn't the method "toString", to avoid infinite loops.
+		// 3) The method is public. Note: If "access" is odd, the method is public.
+		// 4) The odds of us visiting this method is greater than (or equal to) a random number we picked.
+		if ( ((mv != null) && !name.equals("toString")) && ((access % 2 == 1) && (randomNumber <= percentage)) ) {
+			mv = new MyMethodVisitor(mv, name, randomNumberGenerator.nextInt(), threadNumber);
+		}
+		return mv;
+	}
+}

--- a/openjdk.test.debugging/src_80/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyMethodVisitor.java
+++ b/openjdk.test.debugging/src_80/test.debugging/net/adoptopenjdk/test/hcrAgent/agent/MyMethodVisitor.java
@@ -15,8 +15,8 @@ limitations under the License.
 
 package net.adoptopenjdk.test.hcrAgent.agent;
 
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
 
 /*
  * This class inserts new byte codes into an existing Java class.
@@ -36,7 +36,7 @@ public class MyMethodVisitor extends MethodVisitor {
 	 * @param threadNumber Used to generate thread-specific log messages, as many of these may be running at once.
 	 */
 	public MyMethodVisitor(MethodVisitor mv, String methodName, int randomNumber, int threadNumber) {
-		super(Opcodes.ASM7, mv);
+		super(Opcodes.ASM4, mv);
 		methodNameLocal = methodName;
 		this.randomNumber = randomNumber;
 		this.threadNumber = threadNumber;


### PR DESCRIPTION
- Change asm to jvm asm
- Set different Opcodes.ASM versions for jdk 8 and 11+
- Related Issue: https://github.com/eclipse/openj9/issues/11642
- Need to merge with PR (https://github.com/AdoptOpenJDK/openjdk-tests/pull/2182) together.

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>