### PR TITLE
Increase individual test timeout from 10 min to 20 min

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -571,7 +571,7 @@ public class Jck implements StfPluginInterface {
 				throw new StfException("Unknown platform:: " + platform);
 			}
 			fileContent += "concurrency " + concurrencyString + ";\n";
-			fileContent += "timeoutfactor 1" + ";\n";				// java_awt and javax_management require more than 1h to finish tests
+			fileContent += "timeoutfactor 2" + ";\n";	// 2 base time limit equal 20 minutes
 			fileContent += keyword + ";\n";
 			
 			if (platform.equals("win32")) {


### PR DESCRIPTION
Each test's timeout limit is multiplied by the time factor value. One base time limit is 10 minutes, increase it to 20 minutes.
This is reflected by the `timeoutSeconds` value within `jtr` file.

Note: there were individual tests take slightly more than 10 min to finish in certain `ppc64le_linux` machines. Verified with this PR, the test in question passes in 10x grinder.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>