### PR TITLE
Enable time-based load test mechanism in openjdk-systemtest load tests

### DIFF
--- a/openjdk.build/makefile
+++ b/openjdk.build/makefile
@@ -591,7 +591,7 @@ test.LockingLoadTest:
 	echo Target $@ completed
 test.MathLoadTest_all:
 	echo Running target $@
-	$(STF_COMMAND) -test=MathLoadTest $(LOG)
+	$(STF_COMMAND) -test=MathLoadTest -test-args="workload=math" $(LOG)
 	echo Target $@ completed
 test.MathLoadTest_autosimd:
 	echo Running target $@
@@ -603,15 +603,15 @@ test.MathLoadTest_bigdecimal:
 	echo Target $@ completed
 test.MauveSingleThreadLoadTest:
 	echo Running target $@
-	$(STF_COMMAND) -test=MauveSingleThreadLoadTest $(LOG)
+	$(STF_COMMAND) -test=MauveSingleThrdLoad $(LOG)
 	echo Target $@ completed
 test.MauveSingleInvocationLoadTest:
 	echo Running target $@
-	$(STF_COMMAND) -test=MauveSingleInvocationLoadTest $(LOG)
+	$(STF_COMMAND) -test=MauveSingleInvocLoad $(LOG)
 	echo Target $@ completed
 test.MauveMultiThreadLoadTest:
 	echo Running target $@
-	$(STF_COMMAND) -test=MauveMultiThreadLoadTest $(LOG)
+	$(STF_COMMAND) -test=MauveMultiThrdLoad $(LOG)
 	echo Target $@ completed
 test.NioLoadTest:
 	echo Running target $@

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleInvocLoad.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleInvocLoad.java
@@ -15,27 +15,21 @@
 package net.adoptopenjdk.stf;
 
 import net.adoptopenjdk.loadTest.InventoryData;
+import net.adoptopenjdk.loadTest.TimeBasedLoadTest;
 import net.adoptopenjdk.stf.environment.FileRef;
 import net.adoptopenjdk.stf.environment.JavaVersion;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension.Echo;
 import net.adoptopenjdk.stf.processes.ExpectedOutcome;
-import net.adoptopenjdk.stf.plugin.interfaces.StfPluginInterface;
 import net.adoptopenjdk.stf.processes.definitions.LoadTestProcessDefinition;
 import net.adoptopenjdk.stf.runner.modes.HelpTextGenerator;
 
-public class MauveSingleInvocLoad implements StfPluginInterface {
+public class MauveSingleInvocLoad extends TimeBasedLoadTest {
 	public void help(HelpTextGenerator help) throws StfException {
 		help.outputSection("MauveSingleInvocLoad");
 		help.outputText("The MauveSingleInvocLoad runs a subset of tests from the GNU mauve project. "
 				+ "The tests are run once to identify any issues which do not actually require a load test "
 				+ "(multi-invocation or multi-thread to reveal themselves");
-	}
-
-	public void pluginInit(StfCoreExtension stf) throws StfException {
-	}
-
-	public void setUp(StfCoreExtension test) throws StfException {
 	}
 
 	public void execute(StfCoreExtension test) throws StfException {
@@ -67,19 +61,25 @@ public class MauveSingleInvocLoad implements StfPluginInterface {
 		
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addJvmOption(modularityOptions)
-				.addJarToClasspath(mauveJar)
-				.addSuite("mauve")
-				.setSuiteInventory(inventoryFile)
-				.setSuiteThreadCount(1)
-				.setSuiteNumTests(numMauveTests) // Run each test once times
-				.setSuiteSequentialSelection();
-//				.setSuiteRandomSelection();
+				.addJarToClasspath(mauveJar); 
 		
+		if (isTimeBasedLoadTest) { 
+			loadTestInvocation = loadTestInvocation.setTimeLimit(timeLimit);	// If it's a time based test, stop execution after given time duration
+		}
+		
+		loadTestInvocation = loadTestInvocation.addSuite("mauve")
+				.setSuiteInventory(inventoryFile)
+				.setSuiteThreadCount(1); 
+		
+		if (!isTimeBasedLoadTest) { 
+			loadTestInvocation = loadTestInvocation.setSuiteNumTests(numMauveTests * 500); // Run each test 500 times
+		}
+		
+		loadTestInvocation = loadTestInvocation.setSuiteSequentialSelection();
+
 		test.doRunForegroundProcess("Run Mauve load test", "LT", Echo.ECHO_ON,
-				ExpectedOutcome.cleanRun().within("1h"), 
+				ExpectedOutcome.cleanRun().within(finalTimeout), 
 				loadTestInvocation);
 	}
-
-	public void tearDown(StfCoreExtension stf) throws StfException {
-	}
 }
+

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleThrdLoad.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MauveSingleThrdLoad.java
@@ -15,27 +15,21 @@
 package net.adoptopenjdk.stf;
 
 import net.adoptopenjdk.loadTest.InventoryData;
+import net.adoptopenjdk.loadTest.TimeBasedLoadTest;
 import net.adoptopenjdk.stf.environment.FileRef;
 import net.adoptopenjdk.stf.environment.JavaVersion;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension.Echo;
 import net.adoptopenjdk.stf.processes.ExpectedOutcome;
-import net.adoptopenjdk.stf.plugin.interfaces.StfPluginInterface;
 import net.adoptopenjdk.stf.processes.definitions.LoadTestProcessDefinition;
 import net.adoptopenjdk.stf.runner.modes.HelpTextGenerator;
 
-public class MauveSingleThrdLoad implements StfPluginInterface {
+public class MauveSingleThrdLoad extends TimeBasedLoadTest {
 	public void help(HelpTextGenerator help) throws StfException {
 		help.outputSection("MauveSingleThrdLoad");
 		help.outputText("The MauveSingleThrdLoad runs a subset of tests from the GNU mauve project. "
 				+ "The tests run on a single thread because some of them exercise swing and awt "
 				+ "which are not thread safe");
-	}
-
-	public void pluginInit(StfCoreExtension stf) throws StfException {
-	}
-
-	public void setUp(StfCoreExtension test) throws StfException {
 	}
 
 	public void execute(StfCoreExtension test) throws StfException {
@@ -67,19 +61,25 @@ public class MauveSingleThrdLoad implements StfPluginInterface {
 		
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addJvmOption(modularityOptions)
-				.addJarToClasspath(mauveJar)
-				.addSuite("mauve")
+				.addJarToClasspath(mauveJar); 
+		
+		if (isTimeBasedLoadTest) { 
+			loadTestInvocation = loadTestInvocation.setTimeLimit(timeLimit);	// If it's a time based test, stop execution after given time duration
+		}
+		
+		loadTestInvocation = loadTestInvocation.addSuite("mauve")
 				.setSuiteInventory(inventoryFile)
-				.setSuiteThreadCount(1)
-				.setSuiteNumTests(numMauveTests * 500) // Run each test 500 times
-				.setSuiteSequentialSelection();
-//				.setSuiteRandomSelection();
+				.setSuiteThreadCount(1);
+				
+		if (!isTimeBasedLoadTest) { 
+			loadTestInvocation = loadTestInvocation.setSuiteNumTests(numMauveTests * 500); // Run each test 500 times
+		}
+		
+		loadTestInvocation = loadTestInvocation.setSuiteSequentialSelection();
 		
 		test.doRunForegroundProcess("Run Mauve load test", "LT", Echo.ECHO_ON,
-				ExpectedOutcome.cleanRun().within("1h"), 
+				ExpectedOutcome.cleanRun().within(finalTimeout), 
 				loadTestInvocation);
 	}
-
-	public void tearDown(StfCoreExtension stf) throws StfException {
-	}
 }
+

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MixedLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MixedLoadTest.java
@@ -14,49 +14,24 @@
 
 package net.adoptopenjdk.stf;
 
+import net.adoptopenjdk.loadTest.InventoryData;
+import net.adoptopenjdk.loadTest.TimeBasedLoadTest;
+import net.adoptopenjdk.stf.environment.FileRef;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension.Echo;
-import net.adoptopenjdk.stf.environment.FileRef;
-import net.adoptopenjdk.stf.plugin.interfaces.StfPluginInterface;
 import net.adoptopenjdk.stf.processes.ExpectedOutcome;
 import net.adoptopenjdk.stf.processes.definitions.JavaProcessDefinition;
 import net.adoptopenjdk.stf.processes.definitions.LoadTestProcessDefinition;
 import net.adoptopenjdk.stf.runner.modes.HelpTextGenerator;
-import net.adoptopenjdk.stf.util.TimeParser;
-import net.adoptopenjdk.loadTest.InventoryData;
-import net.adoptopenjdk.stf.environment.StfTestArguments; 
 
-public class MixedLoadTest implements StfPluginInterface {
-	
-	String timeLimit;
-	int testCountMultiplier;
-	boolean isTimeBasedLoadTest = true;
-	String defaultTimeout = "3h";
+public class MixedLoadTest extends TimeBasedLoadTest {
 	
 	public void help(HelpTextGenerator help) throws StfException {
 		help.outputSection("MixedLoadTest runs workloads of math,mauve,nio,lang,concurrent unit tests");
 		help.outputText("");
 	}
 
-	public void pluginInit(StfCoreExtension stf) throws StfException {
-		// When used as a time based test, this STF test plugin accepts the following two parameters:
-		//   (1) timeLimit     	     : Time duration (e.g. 5s, 5m, 5h) for which the load should be run. 
-		//   (2) testCountMultiplier : Optional multiplier value to increase the workload externally.
-		StfTestArguments testArgs = stf.env().getTestProperties("timeLimit=[notset]","testCountMultiplier=[1]");
-		timeLimit = testArgs.get("timeLimit");
-		testCountMultiplier = Integer.parseInt(testArgs.get("testCountMultiplier"));
-		
-		// When We are using MixedLoadTest for default cases;. e.g. not in a time based load test scenario 
-		if ( timeLimit.equals("notset")) {
-			isTimeBasedLoadTest = false; 
-		}
-	}
-
-	public void setUp(StfCoreExtension test) throws StfException {
-	}
-
 	public void execute(StfCoreExtension test) throws StfException {
-		
 		FileRef mauveJar = test.env().findPrereqFile("mauve/mauve.jar");
 		FileRef fileSystemJar = test.env().findTestFile("openjdk.test.nio/bin/lib/filesystem.jar");
 
@@ -83,38 +58,24 @@ public class MixedLoadTest implements StfPluginInterface {
 				.addJarToClasspath(fileSystemJar);
 				
 		if (isTimeBasedLoadTest) { 
-			loadTestInvocation = loadTestInvocation.setTimeLimit(timeLimit);	// If it's a time based test, stop execution after given time duration
+			loadTestInvocation = loadTestInvocation.setTimeLimit(timeLimit); // If it's a time based test, stop execution after given time duration
 		}
+		
 		loadTestInvocation = loadTestInvocation.setAbortIfOutOfMemory(false)
 				.addSuite("mix")
 				.setSuiteThreadCount(cpuCount - 2, 10); // Leave 1 cpu for the JIT, 1 cpu for GC and set min 10
-		if (isTimeBasedLoadTest) { 
-			loadTestInvocation = loadTestInvocation
-				.setSuiteNumTests(totalTests * 80000000 * testCountMultiplier); // If it's a time based test, run a very large load
-		} else {  
-			loadTestInvocation = loadTestInvocation
-				.setSuiteNumTests(totalTests * 200);
+		
+		if (!isTimeBasedLoadTest) { 
+			loadTestInvocation = loadTestInvocation.setSuiteNumTests(totalTests * 200);
 		}
 		
 		loadTestInvocation = loadTestInvocation
 				.setSuiteInventory(inventoryFile) 		// Point at the file which lists the tests
 				.setSuiteRandomSelection(); 			// Randomly pick the next test each time
 		
-		String finalTimeout = defaultTimeout;
-		
-		// If it's a time-based test, set timeout for the test process to the default timeout(3h) + given timeLimit
-		if (isTimeBasedLoadTest) { 
-			long finalTimeoutInSeconds = TimeParser.parseTimeSpecification(defaultTimeout).getSeconds() + 
-					TimeParser.parseTimeSpecification(timeLimit).getSeconds();
-			finalTimeout = finalTimeoutInSeconds + "s"; 
-		}
-		
 		test.doRunForegroundProcess("Run mixed unit tests", "LT", Echo.ECHO_ON,
 				ExpectedOutcome.cleanRun().within(finalTimeout), 
 				loadTestInvocation);		
 			
-	}
-
-	public void tearDown(StfCoreExtension stf) throws StfException {
 	}
 }

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/UtilLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/UtilLoadTest.java
@@ -14,25 +14,19 @@
 
 package net.adoptopenjdk.stf;
 
+import net.adoptopenjdk.loadTest.InventoryData;
+import net.adoptopenjdk.loadTest.TimeBasedLoadTest;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension.Echo;
-import net.adoptopenjdk.stf.plugin.interfaces.StfPluginInterface;
 import net.adoptopenjdk.stf.processes.ExpectedOutcome;
 import net.adoptopenjdk.stf.processes.definitions.JavaProcessDefinition;
 import net.adoptopenjdk.stf.processes.definitions.LoadTestProcessDefinition;
 import net.adoptopenjdk.stf.runner.modes.HelpTextGenerator;
-import net.adoptopenjdk.loadTest.InventoryData;
 
-public class UtilLoadTest implements StfPluginInterface {
+public class UtilLoadTest extends TimeBasedLoadTest {
 	public void help(HelpTextGenerator help) throws StfException {
 		help.outputSection("UtilLoadTest runs a workload of Java util related tests");
 		help.outputText("");
-	}
-
-	public void pluginInit(StfCoreExtension stf) throws StfException {
-	}
-
-	public void setUp(StfCoreExtension test) throws StfException {
 	}
 
 	public void execute(StfCoreExtension test) throws StfException {
@@ -43,19 +37,25 @@ public class UtilLoadTest implements StfPluginInterface {
 		LoadTestProcessDefinition loadTestInvocation = test.createLoadTestSpecification()
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.JUNIT)
 				.addPrereqJarToClasspath(JavaProcessDefinition.JarId.HAMCREST)
-				.addProjectToClasspath("openjdk.test.util")
-				.setAbortIfOutOfMemory(false)
+				.addProjectToClasspath("openjdk.test.util");
+		
+		if (isTimeBasedLoadTest) { 
+			loadTestInvocation = loadTestInvocation.setTimeLimit(timeLimit);	// If it's a time based test, stop execution after given time duration
+		}
+		
+		loadTestInvocation = loadTestInvocation.setAbortIfOutOfMemory(false)
 				.addSuite("util")
 				.setSuiteThreadCount(cpuCount - 1, 2)	  	// Leave 1 cpu for the JIT and set min 2
-				.setSuiteInventory(inventoryFile) 		// Point at the file which lists the tests
-				.setSuiteNumTests(totalTests * 500)		// Run for about 2 minutes with no -X options
-				.setSuiteRandomSelection();		  	// Randomly pick the next test each time
+				.setSuiteInventory(inventoryFile); 		// Point at the file which lists the tests
+		
+		if (!isTimeBasedLoadTest) { 
+			loadTestInvocation = loadTestInvocation.setSuiteNumTests(totalTests * 500);		// Run for about 2 minutes with no -X options
+		}
+		
+		loadTestInvocation = loadTestInvocation.setSuiteRandomSelection();		  	// Randomly pick the next test each time
 		
 		test.doRunForegroundProcess("Run util load tests", "ULT", Echo.ECHO_ON,
 				ExpectedOutcome.cleanRun().within("1h"), 
 				loadTestInvocation);
-	}
-
-	public void tearDown(StfCoreExtension stf) throws StfException {
 	}
 }


### PR DESCRIPTION
- Add time-based execution mechanism in STF load tests
- Related to https://github.com/AdoptOpenJDK/openjdk-tests/issues/2104

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>