### PR TITLE
Correct URL for STF repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mkdir -p $HOME/git
 
 # 2. Clone the STF repository
 cd $HOME/git
-git clone git@github.com:adoptium/stf.git stf
+git clone git@github.com:adoptium/STF.git stf
 
 # 3. Clone the aqa-systemtest repository
 cd $HOME/git
@@ -67,7 +67,7 @@ mkdir c:\%USERPROFILE%\git
 
 REM 2. Clone the STF repository
 cd c:\%USERPROFILE%\git
-git clone git@github.com:adoptium/stf.git stf
+git clone git@github.com:adoptium/STF.git stf
 
 REM 3. Clone the test cases repository
 cd c:\%USERPROFILE%\git

--- a/openjdk.build/docs/build.md
+++ b/openjdk.build/docs/build.md
@@ -40,7 +40,7 @@ These prereqs must be installed before attempting to build aqa-systemtest
 | wget                  | https://www.gnu.org/copyleft/gpl.html                         | stf.build, openjdk.build | Windows - download from https://sourceforge.net/projects/gnuwin32/files/wget/1.11.4-1/wget-1.11.4-1-bin.zip<br>This needs below dependency so download it from <br>https://sourceforge.net/projects/gnuwin32/files/wget/1.11.4-1/wget-1.11.4-1-dep.zip                                                                                                                                                | Add both downloads to PATH                                                                                                                                                                                                                                                           | No                                 |
 
 ## Building from a command line
-1. git clone https://github.com/adoptium/stf.git stf
+1. git clone https://github.com/adoptium/STF.git stf
 1. git clone https://github.com/adoptium/aqa-systemtest.git aqa-systemtest
 1. cd &lt;git-root&gt;openjdk.build
 1. make
@@ -88,7 +88,7 @@ make test LOGDIR=$HOME
 LOGDIR must exist prior to invoking the test.
 
 The commands which write to the log file always succeed whether or not the preceding test passed or failed.
-This means that all the tests will be run if LOGDIR= is used even if the make -k (keep going) option is not used. 
+This means that all the tests will be run if LOGDIR= is used even if the make -k (keep going) option is not used.
 
 ### Executing a test plan
 Individual projects also contain testplan.xml files which define more elaborate plans combining the test cases
@@ -104,7 +104,7 @@ will list all the tests in the stf and aqa-systemtest repositories (the stf repo
 ```
 perl $HOME/git/stf/stf.pl -test-root="$HOME/git/aqa-systemtest" -test=xxxx
 ```
-will execute the test xxxx.  
+will execute the test xxxx.
 Some tests require test specific arguments:
 ```
 perl $HOME/git/stf/stf.pl -test-root="$HOME/git/aqa-systemtest" -test=xxxx
@@ -114,4 +114,3 @@ JVM arguments can be passed to the Java command run during the test via:
 perl $HOME/git/stf/stf.pl -test-root="$HOME/git/aqa-systemtest" -java-args="-Xint" -test=xxxx
 ```
 For a full list of ways to direct stf behaviour refer to the stf documentation in the stf repository https://github.com/adoptium/stf.
-

--- a/openjdk.build/scripts/aqa-systemtest-clone-make.bat
+++ b/openjdk.build/scripts/aqa-systemtest-clone-make.bat
@@ -13,7 +13,7 @@ REM limitations under the License.
 REM Save current directory
 set currdir=%cd%
 REM Clone stf
-(IF NOT EXIST %USERPROFILE%\git mkdir %USERPROFILE%\git) && cd %USERPROFILE%\git && (IF EXIST stf rmdir /s /q stf) && git clone https://github.com/adoptium/stf.git stf
+(IF NOT EXIST %USERPROFILE%\git mkdir %USERPROFILE%\git) && cd %USERPROFILE%\git && (IF EXIST stf rmdir /s /q stf) && git clone https://github.com/adoptium/STF.git stf
 REM Clone aqa-systemtest
 (IF NOT EXIST %USERPROFILE%\git mkdir %USERPROFILE%\git) && cd %USERPROFILE%\git && (IF EXIST aqa-systemtest rmdir /s /q aqa-systemtest) && git clone https://github.com/adoptium/aqa-systemtest.git aqa-systemtest
 REM Configure (get prereqs)

--- a/openjdk.build/scripts/aqa-systemtest-clone-make.sh
+++ b/openjdk.build/scripts/aqa-systemtest-clone-make.sh
@@ -14,7 +14,7 @@
 #-------------------------------------------------------------------------
 
 # Clone stf
-mkdir -p $HOME/git && cd $HOME/git && rm -rf stf && mkdir stf && git clone https://github.com/adoptium/stf.git stf
+mkdir -p $HOME/git && cd $HOME/git && rm -rf stf && mkdir stf && git clone https://github.com/adoptium/STF.git stf
 if [ "$?" != "0" ]; then
     echo "Error cloning stf" 1>&2
     exit 1


### PR DESCRIPTION
The URL ends with `STF.git`, not `stf.git`.