### PR TITLE
Build the tests with release=8 whenever it is possible

### DIFF
--- a/openjdk.test.mauve/build.xml
+++ b/openjdk.test.mauve/build.xml
@@ -106,10 +106,11 @@ limitations under the License.
 			<exclude name="/junit/textui/*.java" />
 		</depend>
 		-->
-		<!-- The test cases are built with source="1.8" and target="1.8" because they need packages
-		    which have been moved into madules which are not visible by default in Java 9. -->
+		<!-- The test cases are built with release="8" if supported by the compiler,
+		    otherwise with source="1.8" and target="1.8". -->
 		<javac srcdir="${openjdk_test_mauve_src_dir}"
 			   destdir="${openjdk_test_mauve_src_dir}"
+			   release="8"
 			   source="1.8"
 			   target="1.8"
 			   fork="true"
@@ -124,6 +125,23 @@ limitations under the License.
 			<exclude name="**/junit/framework/*.java" />
 			<exclude name="/junit/runner/*.java" />
 			<exclude name="/junit/textui/*.java" />
+			<exclude name="**/gnu/testlet/java/lang/Class/classInfo/getDeclaredMethod.java" />
+		</javac>
+		<!-- The file gnu/testlet/java/lang/Class/classInfo/getDeclaredMethod.java is built with
+		    source="1.8" and target="1.8" because it requires sun.reflect.annotation.AnnotationType
+		    that is in module not visible by default in Java 9 and later when using release=8. -->
+		<javac srcdir="${openjdk_test_mauve_src_dir}"
+			   destdir="${openjdk_test_mauve_src_dir}"
+			   source="1.8"
+			   target="1.8"
+			   fork="true"
+			   executable="${java_compiler}"
+			   classpathref="project.class.path"
+			   debug="true"
+			   encoding="${src-encoding}"
+			   includeantruntime="false"
+			   failonerror="true">
+			<include name="**/gnu/testlet/java/lang/Class/classInfo/getDeclaredMethod.java" />
 		</javac>
 	</target>
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/19888

The tests have to be built with release=8 in order to avoid calling the new overridden methods with covariant return types in java.nio.ByteBuffer/CharBuffer/LongBuffer, like position(int), rewind, flip...
The only source file that has to be built with source=1.8 and target=1.8 is the gnu/testlet/java/lang/Class/classInfo/getDeclaredMethod.java, because it requires sun.reflect.annotation.AnnotationType that is not visible using release=8 from jdk9+
The specifying of release="8", source="1.8" and target="1.8" allows ant 1.10.x to use either release if supported or the source/target if release is not supported.