### PR TITLE
Remove -b option

### DIFF
--- a/openjdk.test.mauve/build.xml
+++ b/openjdk.test.mauve/build.xml
@@ -361,7 +361,6 @@ limitations under the License.
 
 	<target name="get-source" depends="create-work-dir" unless="openjdk_test_mauve_already_built">
 		<exec dir="${openjdk_test_mauve_work_dir}" executable="git">
-		<arg value="-b master"/>
 		<arg value="https://git.linaro.org/leg/openjdk/mauve.git"/>
 		</exec>
 	</target>


### PR DESCRIPTION
Resolve error on nodes where older git versions do not support -b option

```
get-source:
     [exec] unknown option: -b master
     [exec] usage: git [--version] [--help] [-C <path>] [-c <name>=<value>]
     [exec]            [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
     [exec]            [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]
     [exec]            [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
     [exec]            [--super-prefix=<path>] [--config-env=<name>=<envvar>]
     [exec]            <command> [<args>]
     [exec] Result: 129
```