### PR TITLE
Fix clone command

### DIFF
--- a/openjdk.test.mauve/build.xml
+++ b/openjdk.test.mauve/build.xml
@@ -362,6 +362,8 @@ limitations under the License.
 	<target name="get-source" depends="create-work-dir" unless="openjdk_test_mauve_already_built">
 		<exec dir="${openjdk_test_mauve_work_dir}" executable="git">
 		<arg value="clone"/>
+		<arg value="--depth 1"/>
+		<arg value="-b master"/>
 		<arg value="https://git.linaro.org/leg/openjdk/mauve.git"/>
 		</exec>
 	</target>


### PR DESCRIPTION
Original PR was wrong (missing 'clone'), so all other options were reporting failure.  Noting that getDependency jobs do not have aqa-systemtest parameter, making it less convenient to test, thus the churn).