### PR TITLE
Revert mauve material modifications

### DIFF
--- a/openjdk.test.mauve/build.xml
+++ b/openjdk.test.mauve/build.xml
@@ -51,7 +51,7 @@ limitations under the License.
 	<target name="build-dependencies">
 	</target>
 
-	<target name="configure" depends="check-if-already-built, output-recreate-message, get-source, check-if-source-available, build-archives, check-if-work_jar_file-exists, install-archives, delete-work-dir">
+	<target name="configure" depends="check-if-already-built, check-if-cvs-available, download-cvsclient, output-recreate-message, get-source, check-if-source-available, build-archives, check-if-work_jar_file-exists, install-archives, delete-work-dir">
 	</target>
 
 	<!--
@@ -64,7 +64,7 @@ limitations under the License.
 		   identifer which is illegal in java 9.
 		   This will rebuild from the source and put the results mauve.jar into ${first_prereqs_root}/mauve
 	-->
-	<target name="force-build" depends="check-if-source-available, build-archives, check-if-work_jar_file-exists, install-archives">
+	<target name="force-build" depends="check-if-cvs-available, check-if-source-available, build-archives, check-if-work_jar_file-exists, install-archives">
 	</target>
 
 	<target name="output-recreate-message" if="${openjdk_test_mauve_already_built}">
@@ -359,10 +359,15 @@ limitations under the License.
 		<delete dir="${openjdk_test_mauve_src_dir}/gnu/testlet/org/omg/PortableServer/POAOperations"/>
 	</target>
 
-	<target name="get-source" depends="create-work-dir" unless="openjdk_test_mauve_already_built">
-		<exec dir="${openjdk_test_mauve_work_dir}" executable="git">
-		<arg value="clone"/>
-		<arg value="https://git.linaro.org/leg/openjdk/mauve.git"/>
+	<target name="get-source" depends="download-cvsclient, create-work-dir" unless="openjdk_test_mauve_already_built">
+		<exec dir="${openjdk_test_mauve_work_dir}" executable="java">
+			<arg value="-Dcvs.root=:pserver:anoncvs@sourceware.org:/cvs/mauve"/>
+			<arg value="-jar"/>
+			<arg value="${first_prereqs_root}/cvsclient/org-netbeans-lib-cvsclient.jar"/>
+			<arg value="export"/>
+			<arg value="-r"/>
+			<arg value="HEAD"/>
+			<arg value="mauve"/>
 		</exec>
 	</target>
 
@@ -371,6 +376,17 @@ limitations under the License.
 		<echo message="Checking if ${openjdk_test_mauve_work_dir}/mauve/gnu/testlet/config.java.in exists"/>
 		<available file="${openjdk_test_mauve_work_dir}/mauve/gnu/testlet/config.java.in" property="mauve_source_available"/>
 		<echo message="mauve_source_available is ${mauve_source_available}"/>
+	</target>
+
+	<target name="check-if-cvs-available">
+		<echo message="Checking if ${first_prereqs_root}/cvsclient/org-netbeans-lib-cvsclient.jar exists"/>
+		<available file="${first_prereqs_root}/cvsclient/org-netbeans-lib-cvsclient.jar" property="cvs_available"/>
+		<echo message="cvs_available is ${cvs_available}"/>
+	</target>
+
+	<target name="download-cvsclient" unless="${cvs_available}">
+		<mkdir dir="${first_prereqs_root}/cvsclient"/>
+		<download-file destdir="${first_prereqs_root}/cvsclient" destfile="org-netbeans-lib-cvsclient.jar" srcurl="https://repo1.maven.org/maven2/org/netbeans/lib/cvsclient/20060125/cvsclient-20060125.jar"/>
 	</target>
 
 	<target name="install-archives" if="openjdk_test_mauve_work_jar_file_exists">


### PR DESCRIPTION
Revert mauve modifications for https://github.com/adoptium/aqa-systemtest/pull/502 to 506
Because the new material is missing class files compared with the old material and caused test failure.

Issue: https://github.com/adoptium/aqa-tests/issues/6659