### PR TITLE
Remove Applet API usage from ClassMapHog for JDK 26

### DIFF
--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
@@ -82,6 +82,13 @@ public class ClassHog
 							continue;
 						}
 					}
+					if (javaVersion >= 26) {
+						// The java.applet has been removed from jdk 26
+						if (classToLoad.startsWith("java.applet") || 
+							classToLoad.startsWith("java.beans.AppletInitializer")) {
+							continue;	
+						}
+					}
 					// use the class loader to get the Class class that represents the class on the current line
 					c = Class.forName (classToLoad);
 					cnt++;

--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
@@ -125,6 +125,13 @@ public class ClassMapHog
 								continue;
 							}
 						}
+						if (javaVersion >= 26) {
+							// The java.applet has been removed from jdk 26
+							if (classToLoad.startsWith("java.applet") || 
+								classToLoad.startsWith("java.beans.AppletInitializer")) {
+								continue;	
+							}
+						}
 						// get the class loader to load the current class
 						// Class is the class that represents a classes 'blueprint'
 						c = Class.forName (classToLoad);


### PR DESCRIPTION
- Skip java.applet class loading for JDK 26 from ClassHog and ClassMapHog

related: https://github.com/adoptium/aqa-tests/issues/6705