### PR TITLE
Add debugging for AIOOBE to MessageHeader.parse()

### DIFF
--- a/openjdk.test.nio/src/test.nio/net/adoptopenjdk/test/nio2/util/MessageHeader.java
+++ b/openjdk.test.nio/src/test.nio/net/adoptopenjdk/test/nio2/util/MessageHeader.java
@@ -41,11 +41,11 @@ public class MessageHeader {
 				}
 				try {
 					map.put(keyValue[0], keyValue[1]);
-				} catch (NullPointerException e) {
-					NullPointerException npe = new NullPointerException("parts[" + index + "] '" + parts[index] + "' split length "
-							+ keyValue.length + " [0] '" + keyValue[0] + "' [1] '" + keyValue[1] + "'");
-					npe.initCause(e);
-					throw npe;
+				} catch (ArrayIndexOutOfBoundsException e) {
+					ArrayIndexOutOfBoundsException boundsex = new ArrayIndexOutOfBoundsException("parts[" + index + "] '" + parts[index] + "' split length "
+							+ keyValue.length + " [0] '" + keyValue[0] + "'");
+					boundsex.initCause(e);
+					throw boundsex;
 				}
 			}
 		}


### PR DESCRIPTION
I got it wrong in https://github.com/adoptium/aqa-systemtest/pull/511 the exception is ArrayIndexOutOfBoundsException not NullPointerException.

Tested in https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/5186/